### PR TITLE
ocagent: v1 code started

### DIFF
--- a/v1/common.go
+++ b/v1/common.go
@@ -1,0 +1,38 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+import (
+	"math/rand"
+	"time"
+)
+
+var randSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// retries function fn upto n times, if fn returns an error lest it returns nil early.
+// It applies exponential backoff in units of (1<<n) + jitter microsends.
+func nTriesWithExponentialBackoff(nTries int64, timeBaseUnit time.Duration, fn func() error) (err error) {
+	for i := int64(0); i < nTries; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		// Backoff for a time period with a pseudo-random jitter
+		jitter := time.Duration(randSrc.Float64()*100) * time.Microsecond
+		ts := jitter + ((1 << uint64(i)) * timeBaseUnit)
+		<-time.After(ts)
+	}
+	return err
+}

--- a/v1/example_test.go
+++ b/v1/example_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/ocagent/v1"
+	"go.opencensus.io/trace"
+)
+
+func Example() {
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithServiceName("engine"))
+	if err != nil {
+		log.Fatalf("Failed to create the agent exporter: %v", err)
+	}
+	defer exp.Stop()
+
+	// Now register it as a trace exporter.
+	trace.RegisterExporter(exp)
+
+	// Then use the OpenCensus tracing library, like we normally would.
+	ctx, span := trace.StartSpan(context.Background(), "AgentExporter-Example")
+	defer span.End()
+
+	for i := 0; i < 10; i++ {
+		_, iSpan := trace.StartSpan(ctx, fmt.Sprintf("Sample-%d", i))
+		<-time.After(6 * time.Millisecond)
+		iSpan.End()
+	}
+}

--- a/v1/mock_agent_test.go
+++ b/v1/mock_agent_test.go
@@ -1,0 +1,221 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent_test
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+)
+
+func makeMockAgent(t *testing.T) *mockAgent {
+	return &mockAgent{configsToSend: make(chan *agenttracepb.UpdatedLibraryConfig), t: t, wg: new(sync.WaitGroup)}
+}
+
+type mockAgent struct {
+	t *testing.T
+
+	spans []*tracepb.Span
+	mu    sync.Mutex
+	wg    *sync.WaitGroup
+
+	traceNodes      []*commonpb.Node
+	receivedConfigs []*agenttracepb.CurrentLibraryConfig
+
+	configsToSend          chan *agenttracepb.UpdatedLibraryConfig
+	closeConfigsToSendOnce sync.Once
+
+	port     uint16
+	stopFunc func() error
+	stopOnce sync.Once
+}
+
+var _ agenttracepb.TraceServiceServer = (*mockAgent)(nil)
+
+func (ma *mockAgent) Config(tscs agenttracepb.TraceService_ConfigServer) error {
+	ma.mu.Lock()
+	ma.wg.Add(1)
+	ma.mu.Unlock()
+	defer func() {
+		ma.mu.Lock()
+		ma.wg.Done()
+		ma.mu.Unlock()
+	}()
+
+	in, err := tscs.Recv()
+	if err != nil {
+		return err
+	}
+	if in == nil || in.Node == nil {
+		return fmt.Errorf("the first message must contain the node identifier")
+	}
+	ma.receivedConfigs = append(ma.receivedConfigs, in)
+
+	// Push down all the configs
+	for cfg := range ma.configsToSend {
+		// Push down configs
+		if err := tscs.Send(cfg); err != nil {
+			return err
+		}
+
+		// And then get back the config sent back by the client library
+		back, err := tscs.Recv()
+		if err != nil {
+			return err
+		}
+		ma.receivedConfigs = append(ma.receivedConfigs, back)
+	}
+
+	// Just for the sake of draining any configs
+	// that the client-side exporter is still sending.
+	for {
+		back, err := tscs.Recv()
+		if err != nil {
+			return err
+		}
+		ma.receivedConfigs = append(ma.receivedConfigs, back)
+	}
+	return nil
+}
+
+func (ma *mockAgent) Export(tses agenttracepb.TraceService_ExportServer) error {
+	in, err := tses.Recv()
+	if err != nil {
+		return err
+	}
+
+	ma.mu.Lock()
+	ma.wg.Add(1)
+	ma.mu.Unlock()
+	defer func() {
+		ma.mu.Lock()
+		ma.wg.Done()
+		ma.mu.Unlock()
+	}()
+
+	// The first trace message should contain the node identifier.
+	if in == nil || in.Node == nil {
+		return fmt.Errorf("the first message must contain the node identifier")
+	}
+	ma.traceNodes = append(ma.traceNodes, in.Node)
+
+	// Now that we have the node identifier, let's start receiving spans.
+	for {
+		req, err := tses.Recv()
+		if err != nil {
+			return err
+		}
+		ma.mu.Lock()
+		ma.spans = append(ma.spans, req.Spans...)
+		ma.traceNodes = append(ma.traceNodes, req.Node)
+		ma.mu.Unlock()
+	}
+
+	return nil
+}
+
+func (ma *mockAgent) transitionToReceivingClientConfigs() {
+	// Since we are done sending all the configs, close the configsChannel
+	// so that the state can transition to receiving all the client configs.
+	ma.closeConfigsToSendOnce.Do(func() {
+		close(ma.configsToSend)
+	})
+}
+
+var errAlreadyStopped = fmt.Errorf("already stopped")
+
+func (ma *mockAgent) stop() error {
+	var err = errAlreadyStopped
+	ma.stopOnce.Do(func() {
+		ma.transitionToReceivingClientConfigs()
+
+		if ma.stopFunc != nil {
+			err = ma.stopFunc()
+		}
+	})
+	// Give it sometime to shutdown.
+	<-time.After(160 * time.Millisecond)
+	ma.mu.Lock()
+	ma.wg.Wait()
+	ma.mu.Unlock()
+	return err
+}
+
+// runMockAgent is a helper function to create a mockAgent
+func runMockAgent(t *testing.T) *mockAgent {
+	return runMockAgentAtAddr(t, ":0")
+}
+
+func runMockAgentAtAddr(t *testing.T, addr string) *mockAgent {
+	var deferFuncs []func() error
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("Failed to get an address: %v", err)
+	}
+	deferFuncs = append(deferFuncs, ln.Close)
+
+	srv := grpc.NewServer()
+	ma := makeMockAgent(t)
+	agenttracepb.RegisterTraceServiceServer(srv, ma)
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+
+	deferFunc := func() error {
+		srv.Stop()
+		return ln.Close()
+	}
+
+	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
+	agentPort, _ := strconv.Atoi(agentPortStr)
+
+	ma.port = uint16(agentPort)
+	ma.stopFunc = deferFunc
+
+	return ma
+}
+
+func (ma *mockAgent) getSpans() []*tracepb.Span {
+	ma.mu.Lock()
+	spans := append([]*tracepb.Span{}, ma.spans...)
+	ma.mu.Unlock()
+
+	return spans
+}
+
+func (ma *mockAgent) getReceivedConfigs() []*agenttracepb.CurrentLibraryConfig {
+	ma.mu.Lock()
+	receivedConfigs := append([]*agenttracepb.CurrentLibraryConfig{}, ma.receivedConfigs...)
+	ma.mu.Unlock()
+
+	return receivedConfigs
+}
+
+func (ma *mockAgent) getTraceNodes() []*commonpb.Node {
+	ma.mu.Lock()
+	traceNodes := append([]*commonpb.Node{}, ma.traceNodes...)
+	ma.mu.Unlock()
+
+	return traceNodes
+}

--- a/v1/nodeinfo.go
+++ b/v1/nodeinfo.go
@@ -1,0 +1,41 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+import (
+	"os"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	"go.opencensus.io"
+)
+
+func createNodeInfo(nodeName string) *commonpb.Node {
+	return &commonpb.Node{
+		Identifier: &commonpb.ProcessIdentifier{
+			HostName:       os.Getenv("HOSTNAME"),
+			Pid:            uint32(os.Getpid()),
+			StartTimestamp: timeToTimestamp(startTime),
+		},
+		LibraryInfo: &commonpb.LibraryInfo{
+			Language:           commonpb.LibraryInfo_GO_LANG,
+			ExporterVersion:    Version,
+			CoreLibraryVersion: opencensus.Version(),
+		},
+		ServiceInfo: &commonpb.ServiceInfo{
+			Name: nodeName,
+		},
+		Attributes: make(map[string]string),
+	}
+}

--- a/v1/ocagent.go
+++ b/v1/ocagent.go
@@ -1,0 +1,301 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"google.golang.org/api/support/bundler"
+	"google.golang.org/grpc"
+
+	"go.opencensus.io/trace"
+
+	agentcommonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+)
+
+var startupMu sync.Mutex
+var startTime time.Time
+
+func init() {
+	startupMu.Lock()
+	startTime = time.Now()
+	startupMu.Unlock()
+}
+
+var _ trace.Exporter = (*Exporter)(nil)
+
+type Exporter struct {
+	// mu protects the non-atomic and non-channel variables
+	mu              sync.RWMutex
+	started         bool
+	stopped         bool
+	agentPort       uint16
+	agentAddress    string
+	serviceName     string
+	canDialInsecure bool
+	traceSvcClient  agenttracepb.TraceServiceClient
+	traceExporter   agenttracepb.TraceService_ExportClient
+	nodeInfo        *agentcommonpb.Node
+	grpcClientConn  *grpc.ClientConn
+
+	traceBundler *bundler.Bundler
+}
+
+func NewExporter(opts ...ExporterOption) (*Exporter, error) {
+	exp, err := NewUnstartedExporter(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := exp.Start(); err != nil {
+		return nil, err
+	}
+	return exp, nil
+}
+
+const spanDataBufferSize = 300
+
+func NewUnstartedExporter(opts ...ExporterOption) (*Exporter, error) {
+	e := new(Exporter)
+	for _, opt := range opts {
+		opt.withExporter(e)
+	}
+	if e.agentPort <= 0 {
+		e.agentPort = DefaultAgentPort
+	}
+	traceBundler := bundler.NewBundler((*trace.SpanData)(nil), func(bundle interface{}) {
+		e.uploadTraces(bundle.([]*trace.SpanData))
+	})
+	traceBundler.DelayThreshold = 2 * time.Second
+	traceBundler.BundleCountThreshold = spanDataBufferSize
+	e.traceBundler = traceBundler
+	e.nodeInfo = createNodeInfo(e.serviceName)
+	return e, nil
+}
+
+const (
+	maxInitialConfigRetries = 10
+	maxInitialTracesRetries = 10
+)
+
+// Start dials to the agent, establishing a connection to it. It also
+// initiates the Config and Trace services by sending over the initial
+// messages that consist of the node identifier. Start performs a best case
+// attempt to try to send the initial messages, by applying exponential
+// backoff at most 10 times.
+func (ae *Exporter) Start() error {
+	ae.mu.Lock()
+	defer ae.mu.Unlock()
+
+	err := ae.doStartLocked()
+	if err == nil {
+		ae.started = true
+		return nil
+	}
+
+	// Otherwise we have an error and should clean up to avoid leaking resources.
+	ae.started = false
+	if ae.grpcClientConn != nil {
+		ae.grpcClientConn.Close()
+	}
+
+	return err
+}
+
+func (ae *Exporter) prepareAgentAddress() string {
+	if ae.agentAddress != "" {
+		return ae.agentAddress
+	}
+	port := DefaultAgentPort
+	if ae.agentPort > 0 {
+		port = ae.agentPort
+	}
+	return fmt.Sprintf("%s:%d", DefaultAgentHost, port)
+}
+
+func (ae *Exporter) doStartLocked() error {
+	if ae.started {
+		return nil
+	}
+
+	// Now start it
+	cc, err := ae.dialToAgent()
+	if err != nil {
+		return err
+	}
+	ae.grpcClientConn = cc
+
+	// Initiate the trace service by sending over node identifier info.
+	traceSvcClient := agenttracepb.NewTraceServiceClient(cc)
+	traceExporter, err := traceSvcClient.Export(context.Background())
+	if err != nil {
+		return fmt.Errorf("Exporter.Start:: TraceServiceClient: %v", err)
+	}
+
+	firstTraceMessage := &agenttracepb.ExportTraceServiceRequest{Node: ae.nodeInfo}
+	err = nTriesWithExponentialBackoff(maxInitialTracesRetries, 200*time.Microsecond, func() error {
+		return traceExporter.Send(firstTraceMessage)
+	})
+	if err != nil {
+		return fmt.Errorf("Exporter.Start:: Failed to initiate the Config service: %v", err)
+	}
+	ae.traceExporter = traceExporter
+
+	// Initiate the config service by sending over node identifier info.
+	configStream, err := traceSvcClient.Config(context.Background())
+	if err != nil {
+		return fmt.Errorf("Exporter.Start:: ConfigStream: %v", err)
+	}
+	firstCfgMessage := &agenttracepb.CurrentLibraryConfig{Node: ae.nodeInfo}
+	err = nTriesWithExponentialBackoff(maxInitialConfigRetries, 200*time.Microsecond, func() error {
+		return configStream.Send(firstCfgMessage)
+	})
+	if err != nil {
+		return fmt.Errorf("Exporter.Start:: Failed to initiate the Config service: %v", err)
+	}
+
+	// In the background, handle trace configurations that are beamed down
+	// by the agent, but also reply to it with the applied configuration.
+	go ae.handleConfigStreaming(configStream)
+
+	return nil
+}
+
+// dialToAgent performs a best case attempt to dial to the agent.
+// It retries failed dials with:
+//  * gRPC dialTimeout of 1s
+//  * exponential backoff, 5 times with a period of 50ms
+// hence in the worst case of (no agent actually available), it
+// will take at least:
+//      (5 * 1s) + ((1<<5)-1) * 0.01 s = 5s + 1.55s = 6.55s
+func (ae *Exporter) dialToAgent() (*grpc.ClientConn, error) {
+	addr := ae.prepareAgentAddress()
+	dialOpts := []grpc.DialOption{grpc.WithBlock()}
+	if ae.canDialInsecure {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	}
+
+	var cc *grpc.ClientConn
+	dialOpts = append(dialOpts, grpc.WithTimeout(1*time.Second))
+	dialBackoffWaitPeriod := 50 * time.Millisecond
+	err := nTriesWithExponentialBackoff(5, dialBackoffWaitPeriod, func() error {
+		var err error
+		cc, err = grpc.Dial(addr, dialOpts...)
+		return err
+	})
+	return cc, err
+}
+
+func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService_ConfigClient) error {
+	for {
+		recv, err := configStream.Recv()
+		if err != nil {
+			// TODO: Check if this is a transient error or exponential backoff-able.
+			return err
+		}
+		cfg := recv.Config
+		if cfg == nil {
+			continue
+		}
+
+		// Otherwise now apply the trace configuration sent down from the agent
+		if psamp := cfg.GetProbabilitySampler(); psamp != nil {
+			trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(psamp.SamplingProbability)})
+		} else if csamp := cfg.GetConstantSampler(); csamp != nil {
+			alwaysSample := csamp.Decision == true
+			if alwaysSample {
+				trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+			} else {
+				trace.ApplyConfig(trace.Config{DefaultSampler: trace.NeverSample()})
+			}
+		} else { // TODO: Add the rate limiting sampler here
+		}
+
+		// Then finally send back to upstream the newly applied configuration
+		err = configStream.Send(&agenttracepb.CurrentLibraryConfig{Config: &tracepb.TraceConfig{Sampler: cfg.Sampler}})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var (
+	errNotStarted = errors.New("not started")
+)
+
+// Stop shuts down all the connections and resources
+// related to the exporter.
+func (ae *Exporter) Stop() error {
+	ae.mu.Lock()
+	defer ae.mu.Unlock()
+
+	if !ae.started {
+		return errNotStarted
+	}
+	if ae.stopped {
+		// TODO: tell the user that we've already stopped, so perhaps a sentinel error?
+		return nil
+	}
+
+	ae.Flush()
+
+	// Now close the underlying gRPC connection.
+	var err error
+	if ae.grpcClientConn != nil {
+		err = ae.grpcClientConn.Close()
+	}
+
+	// At this point we can change the state variables: started and stopped
+	ae.started = false
+	ae.stopped = true
+
+	return err
+}
+
+func (ae *Exporter) ExportSpan(sd *trace.SpanData) {
+	if sd == nil {
+		return
+	}
+	_ = ae.traceBundler.Add(sd, -1)
+}
+
+func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
+	if len(sdl) == 0 {
+		return
+	}
+	protoSpans := make([]*tracepb.Span, 0, len(sdl))
+	for _, sd := range sdl {
+		if sd != nil {
+			protoSpans = append(protoSpans, ocSpanToProtoSpan(sd))
+		}
+	}
+
+	if len(protoSpans) > 0 {
+		_ = ae.traceExporter.Send(&agenttracepb.ExportTraceServiceRequest{
+			Spans: protoSpans,
+		})
+	}
+}
+
+func (ae *Exporter) Flush() {
+	ae.traceBundler.Flush()
+}

--- a/v1/ocagent_test.go
+++ b/v1/ocagent_test.go
@@ -1,0 +1,329 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/ocagent/v1"
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"go.opencensus.io"
+	"go.opencensus.io/trace"
+)
+
+func TestNewExporter_endToEnd(t *testing.T) {
+	ma := runMockAgent(t)
+	defer ma.stop()
+
+	serviceName := "endToEnd_test"
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port), ocagent.WithServiceName(serviceName))
+	if err != nil {
+		t.Fatalf("Failed to create a new agent exporter: %v", err)
+	}
+	defer exp.Stop()
+
+	// Once we've register the exporter, we can then send over a bunch of spans.
+	trace.RegisterExporter(exp)
+	defer trace.UnregisterExporter(exp)
+
+	// Let the agent push down a couple of configurations.
+	// 1. Always sample
+	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
+		Config: &tracepb.TraceConfig{
+			Sampler: &tracepb.TraceConfig_ConstantSampler{
+				ConstantSampler: &tracepb.ConstantSampler{Decision: true}, // Always sample
+			},
+		},
+	}
+	<-time.After(5 * time.Millisecond)
+
+	// Now create a couple of spans
+	for i := 0; i < 4; i++ {
+		_, span := trace.StartSpan(context.Background(), "AlwaysSample")
+		span.Annotatef([]trace.Attribute{trace.Int64Attribute("i", int64(i))}, "Annotation")
+		span.End()
+	}
+	<-time.After(10 * time.Millisecond)
+	exp.Flush()
+
+	// 2. Never sample
+	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
+		Config: &tracepb.TraceConfig{
+			Sampler: &tracepb.TraceConfig_ConstantSampler{
+				ConstantSampler: &tracepb.ConstantSampler{Decision: false}, // Never sample
+			},
+		},
+	}
+	<-time.After(5 * time.Millisecond)
+	exp.Flush()
+
+	// Now create a couple of spans
+	for i, n := 0, 2; i < n; i++ {
+		_, span := trace.StartSpan(context.Background(), "NeverSample")
+		span.Annotatef([]trace.Attribute{trace.Int64Attribute("i", int64(n-i))}, "Annotation")
+		span.End()
+	}
+	<-time.After(10 * time.Millisecond)
+	exp.Flush()
+
+	// 3. Probability sampler (100%)
+	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
+		Config: &tracepb.TraceConfig{
+			Sampler: &tracepb.TraceConfig_ProbabilitySampler{
+				ProbabilitySampler: &tracepb.ProbabilitySampler{SamplingProbability: 1.0}, // 100% probability
+			},
+		},
+	}
+	<-time.After(5 * time.Millisecond)
+	exp.Flush()
+
+	// Now create a couple of spans
+	for i := 0; i < 3; i++ {
+		_, span := trace.StartSpan(context.Background(), "ProbabilitySampler-100%")
+		span.Annotatef([]trace.Attribute{trace.BoolAttribute("odd", i&1 == 1)}, "Annotation")
+		span.End()
+	}
+	<-time.After(10 * time.Millisecond)
+	exp.Flush()
+
+	// 4. Probability sampler (0%)
+	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
+		Config: &tracepb.TraceConfig{
+			Sampler: &tracepb.TraceConfig_ProbabilitySampler{
+				ProbabilitySampler: &tracepb.ProbabilitySampler{SamplingProbability: 0.0}, // 0% probability
+			},
+		},
+	}
+	<-time.After(5 * time.Millisecond)
+	exp.Flush()
+
+	for i := 0; i < 3; i++ {
+		_, span := trace.StartSpan(context.Background(), "ProbabilitySampler-0%")
+		span.Annotatef([]trace.Attribute{trace.BoolAttribute("even", i&1 == 0)}, "Annotation")
+		span.End()
+	}
+	// Give the traces some time to be exported or dropped by the core library
+	<-time.After(5 * time.Millisecond)
+
+	ma.transitionToReceivingClientConfigs()
+	<-time.After(5 * time.Millisecond)
+
+	// Now invoke Flush on the exporter.
+	exp.Flush()
+	<-time.After(5 * time.Millisecond)
+
+	// Now shutdown the exporter
+	if err := exp.Stop(); err != nil {
+		t.Errorf("Failed to stop the exporter: %v", err)
+	}
+
+	// Shutdown the agent too so that we can begin
+	// verification checks of expected data back.
+	ma.stop()
+
+	// Expecting 5 receivedConfigs: the first one with the nodeInfo
+	// and the rest with {AlwaysSample, NeverSample, 100%, 0%}
+	spans := ma.getSpans()
+	traceNodes := ma.getTraceNodes()
+	receivedConfigs := ma.getReceivedConfigs()
+
+	if g, w := len(receivedConfigs), 5; g != w {
+		t.Errorf("ReceivedConfigs: got %d want %d", g, w)
+	}
+
+	// Expecting 7 spanData that were sampled, given that
+	// two of the trace configs pushed down to the client
+	// were {NeverSample, ProbabilitySampler(0.0)}
+	if g, w := len(spans), 7; g != w {
+		t.Errorf("Spans: got %d want %d", g, w)
+	}
+
+	// Now check that the responses received by the agent properly
+	// contain the node identifier that we expect the exporter to have.
+	wantIdentifier := &commonpb.ProcessIdentifier{
+		HostName: os.Getenv("HOSTNAME"),
+		Pid:      uint32(os.Getpid()),
+	}
+	wantLibraryInfo := &commonpb.LibraryInfo{
+		Language:           commonpb.LibraryInfo_GO_LANG,
+		ExporterVersion:    ocagent.Version,
+		CoreLibraryVersion: opencensus.Version(),
+	}
+	wantServiceInfo := &commonpb.ServiceInfo{
+		Name: serviceName,
+	}
+
+	var firstNodeInConfig, firstNodeInTraceExport *commonpb.Node
+	if len(receivedConfigs) > 0 {
+		firstNodeInConfig = receivedConfigs[0].Node
+	}
+	if len(traceNodes) > 0 {
+		firstNodeInTraceExport = traceNodes[0]
+	}
+	nodeComparisons := []struct {
+		name string
+		node *commonpb.Node
+	}{
+		// Expecting the first config message that the agent got to contain the nodeInfo
+		{name: "Config", node: firstNodeInConfig},
+		// Expecting the first span message that the agent got to contain the nodeInfo
+		{name: "Trace", node: firstNodeInTraceExport},
+	}
+
+	for _, tt := range nodeComparisons {
+		node := tt.node
+		if node == nil {
+			t.Errorf("%q: first message should contain a non-nil Node", tt.name)
+		} else if g, w := node.Identifier, wantIdentifier; !sameProcessIdentifier(g, w) {
+			t.Errorf("%q: ProcessIdentifier mismatch\nGot  %#v\nWant %#v", tt.name, g, w)
+		} else if g, w := node.LibraryInfo, wantLibraryInfo; !sameLibraryInfo(g, w) {
+			t.Errorf("%q: LibraryInfo mismatch\nGot  %#v\nWant %#v", tt.name, g, w)
+		} else if g, w := node.ServiceInfo, wantServiceInfo; !sameServiceInfo(g, w) {
+			t.Errorf("%q: ServiceInfo mismatch\nGot  %#v\nWant %#v", tt.name, g, w)
+		}
+	}
+}
+
+func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
+	ma := runMockAgent(t)
+	defer ma.stop()
+
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port))
+	if err != nil {
+		t.Fatal("Surprisingly connected with a bad port")
+	}
+	defer exp.Stop()
+
+	// Invoke Start numerous times
+	for i := 0; i < 10; i++ {
+		if err := exp.Start(); err != nil {
+			t.Errorf("#%d unexpected Start error: %v", i, err)
+		}
+	}
+
+	exp.Stop()
+	// Invoke Stop numerous times
+	for i := 0; i < 10; i++ {
+		if err := exp.Stop(); err == nil || !strings.Contains(err.Error(), "not started") {
+			t.Errorf(`#%d got error (%v) expected a "not started error"`, i, err)
+		}
+	}
+}
+
+func TestNewExporter_agentConnectionDiesInMidst(t *testing.T) {
+	ma := runMockAgent(t)
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port))
+	if err != nil {
+		t.Fatal("Surprisingly connected with a bad port")
+	}
+	defer exp.Stop()
+
+	if err := exp.Start(); err != nil {
+		t.Fatalf("Unexpected Start error: %v", err)
+	}
+
+	// Stop the agent right away to simulate killing
+	// the connection in the midst of communication.
+	ma.stop()
+
+	exp.ExportSpan(&trace.SpanData{Name: "in the midst"})
+}
+
+// This test takes a long time to run: to skip it, run tests using: -short
+func TestNewExporter_agentOnBadConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping this long running test")
+	}
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to grab an available port: %v", err)
+	}
+	// Firstly close the "agent's" channel: optimistically this address won't get reused ASAP
+	// However, our goal of closing it is to simulate an unavailable connection
+	ln.Close()
+
+	startTime := time.Now()
+	// If this returns in less than 6.5s report an error
+	// since that's a sign that exponential backoff didn't happen.
+	wantMinDuration := (6 * time.Second) + (500 * time.Millisecond)
+	defer func() {
+		timeSpent := time.Now().Sub(startTime)
+		if timeSpent < wantMinDuration {
+			t.Errorf("Took %s, yet with a non-existent connection it should take at least %s",
+				timeSpent, wantMinDuration)
+		}
+	}()
+
+	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
+	agentPort, _ := strconv.Atoi(agentPortStr)
+
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(uint16(agentPort)))
+	if err == nil {
+		t.Fatal("Surprisingly connected to an unavailable non-gRPC connection")
+	}
+	if exp != nil {
+		t.Fatalf("Surprisingly created an exporter: %#v", exp)
+	}
+}
+
+func TestNewExporter_withAddress(t *testing.T) {
+	ma := runMockAgent(t)
+	defer ma.stop()
+
+	addr := fmt.Sprintf("localhost:%d", ma.port)
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(addr))
+	if err != nil {
+		t.Fatal("Surprisingly connected with a bad port")
+	}
+	defer exp.Stop()
+
+	if err := exp.Start(); err != nil {
+		t.Fatalf("Unexpected Start error: %v", err)
+	}
+}
+
+// Best case comparison for information that we can externally introspect
+func sameProcessIdentifier(n1, n2 *commonpb.ProcessIdentifier) bool {
+	if n1 == nil || n2 == nil {
+		return n1 == n2
+	}
+	return n1.HostName == n2.HostName && n1.Pid == n2.Pid
+}
+
+func sameLibraryInfo(li1, li2 *commonpb.LibraryInfo) bool {
+	if li1 == nil || li2 == nil {
+		return li1 == li2
+	}
+	return li1.Language == li2.Language &&
+		li1.ExporterVersion == li2.ExporterVersion &&
+		li1.CoreLibraryVersion == li2.CoreLibraryVersion
+}
+
+func sameServiceInfo(si1, si2 *commonpb.ServiceInfo) bool {
+	if si1 == nil || si2 == nil {
+		return si1 == si2
+	}
+	return si1.Name == si2.Name
+}

--- a/v1/options.go
+++ b/v1/options.go
@@ -1,0 +1,80 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+const (
+	DefaultAgentPort uint16 = 55678
+	DefaultAgentHost string = "localhost"
+)
+
+type ExporterOption interface {
+	withExporter(e *Exporter)
+}
+
+type portSetter uint16
+
+func (ps portSetter) withExporter(e *Exporter) {
+	e.agentPort = uint16(ps)
+}
+
+var _ ExporterOption = (*portSetter)(nil)
+
+type insecureGrpcConnection int
+
+var _ ExporterOption = (*insecureGrpcConnection)(nil)
+
+func (igc *insecureGrpcConnection) withExporter(e *Exporter) {
+	e.canDialInsecure = true
+}
+
+// WithInsecure disables client transport security for the exporter's gRPC connection
+// just like grpc.WithInsecure() https://godoc.org/google.golang.org/grpc#WithInsecure
+// does. Note, by default, client security is required unless WithInsecure is used.
+func WithInsecure() ExporterOption { return new(insecureGrpcConnection) }
+
+// WithPort allows one to override the port that the exporter will
+// connect to the agent on, instead of using DefaultAgentPort.
+func WithPort(port uint16) ExporterOption {
+	return portSetter(port)
+}
+
+type addressSetter string
+
+func (as addressSetter) withExporter(e *Exporter) {
+	e.agentAddress = string(as)
+}
+
+var _ ExporterOption = (*addressSetter)(nil)
+
+// WithAddress allows one to set the address that the exporter will
+// connect to the agent on. If unset, it will instead try to use
+// connect to DefaultAgentHost:DefaultAgentPort
+func WithAddress(addr string) ExporterOption {
+	return addressSetter(addr)
+}
+
+type serviceNameSetter string
+
+func (sns serviceNameSetter) withExporter(e *Exporter) {
+	e.serviceName = string(sns)
+}
+
+var _ ExporterOption = (*serviceNameSetter)(nil)
+
+// WithServiceName allows one to set/override the service name
+// that the exporter will report to the agent.
+func WithServiceName(serviceName string) ExporterOption {
+	return serviceNameSetter(serviceName)
+}

--- a/v1/transform_spans.go
+++ b/v1/transform_spans.go
@@ -1,0 +1,162 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+import (
+	"time"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+func ocSpanToProtoSpan(sd *trace.SpanData) *tracepb.Span {
+	if sd == nil {
+		return nil
+	}
+	var namePtr *tracepb.TruncatableString
+	if sd.Name != "" {
+		namePtr = &tracepb.TruncatableString{Value: sd.Name}
+	}
+	return &tracepb.Span{
+		TraceId:      sd.TraceID[:],
+		SpanId:       sd.SpanID[:],
+		ParentSpanId: sd.ParentSpanID[:],
+		Status:       ocStatusToProtoStatus(sd.Status),
+		StartTime:    timeToTimestamp(sd.StartTime),
+		EndTime:      timeToTimestamp(sd.EndTime),
+		Links:        ocLinksToProtoLinks(sd.Links),
+		Kind:         ocSpanKindToProtoSpanKind(sd.SpanKind),
+		Name:         namePtr,
+		Attributes:   ocAttributesToProtoAttributes(sd.Attributes),
+		Tracestate:   ocTracestateToProtoTracestate(sd.Tracestate),
+	}
+}
+
+var blankStatus trace.Status
+
+func ocStatusToProtoStatus(status trace.Status) *tracepb.Status {
+	if status == blankStatus {
+		return nil
+	}
+	return &tracepb.Status{
+		Code:    status.Code,
+		Message: status.Message,
+	}
+}
+
+func ocLinksToProtoLinks(links []trace.Link) *tracepb.Span_Links {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]*tracepb.Span_Link, 0, len(links))
+	for _, ocLink := range links {
+		// This redefinition is necessary to prevent ocLink.*ID[:] copies
+		// being reused -- in short we need a new ocLink per iteration.
+		ocLink := ocLink
+
+		sl = append(sl, &tracepb.Span_Link{
+			TraceId: ocLink.TraceID[:],
+			SpanId:  ocLink.SpanID[:],
+			Type:    ocLinkTypeToProtoLinkType(ocLink.Type),
+		})
+	}
+
+	return &tracepb.Span_Links{
+		Link: sl,
+	}
+}
+
+func ocLinkTypeToProtoLinkType(oct trace.LinkType) tracepb.Span_Link_Type {
+	switch oct {
+	case trace.LinkTypeChild:
+		return tracepb.Span_Link_CHILD_LINKED_SPAN
+	case trace.LinkTypeParent:
+		return tracepb.Span_Link_PARENT_LINKED_SPAN
+	default:
+		return tracepb.Span_Link_TYPE_UNSPECIFIED
+	}
+}
+
+func ocAttributesToProtoAttributes(attrs map[string]interface{}) *tracepb.Span_Attributes {
+	if len(attrs) == 0 {
+		return nil
+	}
+	outMap := make(map[string]*tracepb.AttributeValue)
+	for k, v := range attrs {
+		switch v := v.(type) {
+		case bool:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_BoolValue{BoolValue: v}}
+
+		case int:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: int64(v)}}
+
+		case int64:
+			outMap[k] = &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: v}}
+
+		case string:
+			outMap[k] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: v},
+				},
+			}
+		}
+	}
+	return &tracepb.Span_Attributes{
+		AttributeMap: outMap,
+	}
+}
+
+func timeToTimestamp(t time.Time) *timestamp.Timestamp {
+	nanoTime := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: nanoTime / 1e9,
+		Nanos:   int32(nanoTime % 1e9),
+	}
+}
+
+func ocSpanKindToProtoSpanKind(kind int) tracepb.Span_SpanKind {
+	switch kind {
+	case trace.SpanKindClient:
+		return tracepb.Span_CLIENT
+	case trace.SpanKindServer:
+		return tracepb.Span_SERVER
+	default:
+		return tracepb.Span_SPAN_KIND_UNSPECIFIED
+	}
+}
+
+func ocTracestateToProtoTracestate(ts *tracestate.Tracestate) *tracepb.Span_Tracestate {
+	if ts == nil {
+		return nil
+	}
+	return &tracepb.Span_Tracestate{
+		Entries: ocTracestateEntriesToProtoTracestateEntries(ts.Entries()),
+	}
+}
+
+func ocTracestateEntriesToProtoTracestateEntries(entries []tracestate.Entry) []*tracepb.Span_Tracestate_Entry {
+	protoEntries := make([]*tracepb.Span_Tracestate_Entry, 0, len(entries))
+	for _, entry := range entries {
+		protoEntries = append(protoEntries, &tracepb.Span_Tracestate_Entry{
+			Key:   entry.Key,
+			Value: entry.Value,
+		})
+	}
+	return protoEntries
+}

--- a/v1/transform_spans_test.go
+++ b/v1/transform_spans_test.go
@@ -1,0 +1,166 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/ocagent/v1"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+func TestOCSpanToProtoSpan_endToEnd(t *testing.T) {
+	// The goal of this test is to ensure that each
+	// spanData is transformed and exported correctly!
+
+	agent := runMockAgent(t)
+	defer agent.stop()
+
+	serviceName := "spanTranslation"
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(agent.port), ocagent.WithServiceName(serviceName))
+	if err != nil {
+		t.Fatalf("Failed to create a new agent exporter: %v", err)
+	}
+	defer exp.Stop()
+
+	startTime := time.Now()
+	endTime := startTime.Add(10 * time.Second)
+	ocTracestate, err := tracestate.New(new(tracestate.Tracestate), tracestate.Entry{Key: "foo", Value: "bar"},
+		tracestate.Entry{Key: "a", Value: "b"})
+	if err != nil || ocTracestate == nil {
+		t.Fatalf("Failed to create ocTracestate: %v", err)
+	}
+
+	ocSpanData := &trace.SpanData{
+		SpanContext: trace.SpanContext{
+			TraceID:    trace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+			SpanID:     trace.SpanID{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
+			Tracestate: ocTracestate,
+		},
+		SpanKind:     trace.SpanKindServer,
+		ParentSpanID: trace.SpanID{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         "End-To-End Here",
+		StartTime:    startTime,
+		EndTime:      endTime,
+		MessageEvents: []trace.MessageEvent{
+			{Time: startTime, EventType: trace.MessageEventTypeSent, UncompressedByteSize: 1024, CompressedByteSize: 512},
+			{Time: endTime, EventType: trace.MessageEventTypeRecv, UncompressedByteSize: 1024, CompressedByteSize: 1000},
+		},
+		Links: []trace.Link{
+			{
+				TraceID: trace.TraceID{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+				SpanID:  trace.SpanID{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+				Type:    trace.LinkTypeParent,
+			},
+			{
+				TraceID: trace.TraceID{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+				SpanID:  trace.SpanID{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+				Type:    trace.LinkTypeChild,
+			},
+		},
+		Status: trace.Status{
+			Code:    trace.StatusCodeInternal,
+			Message: "This is not a drill!",
+		},
+		HasRemoteParent: true,
+		Attributes: map[string]interface{}{
+			"timeout_ns": int64(12e9),
+			"agent":      "ocagent",
+			"cache_hit":  true,
+			"ping_count": int(25), // Should be transformed into int64
+		},
+	}
+
+	// TODO: file a bug with opencensus-go because trace.Annotation.Attributes' type is map[string]interface{}
+	// yet Attribute value and key cannot be easily introspected, so we can't easily test the values.
+
+	exp.ExportSpan(ocSpanData)
+	// Also try to export a nil span and it should never make it
+	exp.ExportSpan(nil)
+	exp.Flush()
+	<-time.After(100 * time.Millisecond)
+	exp.Stop()
+	agent.stop()
+
+	spans := agent.getSpans()
+	if len(spans) == 0 || spans[0] == nil {
+		t.Fatal("Expected the exported span")
+	}
+
+	wantProtoSpan := &tracepb.Span{
+		TraceId:      []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		SpanId:       []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
+		ParentSpanId: []byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         &tracepb.TruncatableString{Value: "End-To-End Here"},
+		Kind:         tracepb.Span_SERVER,
+		StartTime:    timeToTimestamp(startTime),
+		EndTime:      timeToTimestamp(endTime),
+		Status: &tracepb.Status{
+			Code:    13,
+			Message: "This is not a drill!",
+		},
+		Links: &tracepb.Span_Links{
+			Link: []*tracepb.Span_Link{
+				{
+					TraceId: []byte{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+					SpanId:  []byte{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+					Type:    tracepb.Span_Link_PARENT_LINKED_SPAN,
+				},
+				{
+					TraceId: []byte{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+					SpanId:  []byte{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+					Type:    tracepb.Span_Link_CHILD_LINKED_SPAN,
+				},
+			},
+		},
+		Tracestate: &tracepb.Span_Tracestate{
+			Entries: []*tracepb.Span_Tracestate_Entry{
+				{Key: "foo", Value: "bar"},
+				{Key: "a", Value: "b"},
+			},
+		},
+		Attributes: &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"cache_hit":  &tracepb.AttributeValue{Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+				"timeout_ns": &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 12e9}},
+				"ping_count": &tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 25}},
+				"agent": &tracepb.AttributeValue{Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: "ocagent"},
+				}},
+			},
+		},
+	}
+
+	if g, w := spans[0], wantProtoSpan; !reflect.DeepEqual(g, w) {
+		for i := 0; i < len(w.Links.Link); i++ {
+			t.Logf("#%d:: \nGot:  %#v\nWant: %#v\n\n", i, g.Links.Link[i], w.Links.Link[i])
+		}
+		t.Fatalf("End-to-end transformed span\n\tGot  %+v\n\tWant %+v", g, w)
+	}
+}
+
+func timeToTimestamp(t time.Time) *timestamp.Timestamp {
+	nanoTime := t.UnixNano()
+	return &timestamp.Timestamp{
+		Seconds: nanoTime / 1e9,
+		Nanos:   int32(nanoTime % 1e9),
+	}
+}

--- a/v1/version.go
+++ b/v1/version.go
@@ -1,0 +1,17 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+const Version = "0.0.1"


### PR DESCRIPTION
First cut at an agent exporter that can be
hooked into an OpenCensus library/application.
The exporter implements `trace.Exporter`
and it translates `go.opencensus.io/trace`.Span
instances into the agent's proto exchangable
Spans but also conforming to the agent's communication
protocol.