### PR TITLE
README: add usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,43 @@ Ultimately we may want to move the OC-Agent Go Exporter to [OpenCensus Go core l
 ## Installation
 
 ```bash
-$ go get -u contrib.go.opencensus.io/exporter/ocagent
+$ go get -u contrib.go.opencensus.io/exporter/ocagent/v1
 ```
 
 [OCAgentReadme]: https://github.com/census-instrumentation/opencensus-proto/tree/master/opencensus/proto/agent#opencensus-agent-proto
 [OpenCensusGo]: https://github.com/census-instrumentation/opencensus-go
+
+## Usage
+
+```go
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/ocagent/v1"
+	"go.opencensus.io/trace"
+)
+
+func Example() {
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithServiceName("your-service-name"))
+	if err != nil {
+		log.Fatalf("Failed to create the agent exporter: %v", err)
+	}
+	defer exp.Stop()
+
+	// Now register it as a trace exporter.
+	trace.RegisterExporter(exp)
+
+	// Then use the OpenCensus tracing library, like we normally would.
+	ctx, span := trace.StartSpan(context.Background(), "AgentExporter-Example")
+	defer span.End()
+
+	for i := 0; i < 10; i++ {
+		_, iSpan := trace.StartSpan(ctx, fmt.Sprintf("Sample-%d", i))
+		<-time.After(6 * time.Millisecond)
+		iSpan.End()
+	}
+}
+```


### PR DESCRIPTION
The previous README looked blank without any
usage guide. This change copies the code in
the v1/example_test.go file to show an end-to-end
copy pastable example that anyone with an agent
can use.