### PR TITLE
all: Use int instead of uint16 for port.

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -159,12 +159,12 @@ func (da *discardAgent) Export(tses agenttracepb.TraceService_ExportServer) erro
 	}
 }
 
-func parsePort(addr net.Addr) (uint16, error) {
+func parsePort(addr net.Addr) (int, error) {
 	addrStr := addr.String()
 	if i := strings.LastIndex(addrStr, ":"); i < 0 {
 		return 0, errors.New("no `:` found")
 	} else {
 		port, err := strconv.Atoi(addrStr[i+1:])
-		return uint16(port), err
+		return port, err
 	}
 }

--- a/mock_agent_test.go
+++ b/mock_agent_test.go
@@ -187,7 +187,7 @@ func runMockAgentAtAddr(t *testing.T, addr string) *mockAgent {
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
 	agentPort, _ := strconv.Atoi(agentPortStr)
 
-	ma.port = int(agentPort)
+	ma.port = agentPort
 	ma.stopFunc = deferFunc
 
 	return ma

--- a/mock_agent_test.go
+++ b/mock_agent_test.go
@@ -46,7 +46,7 @@ type mockAgent struct {
 	configsToSend          chan *agenttracepb.UpdatedLibraryConfig
 	closeConfigsToSendOnce sync.Once
 
-	port     uint16
+	port     int
 	stopFunc func() error
 	stopOnce sync.Once
 }
@@ -187,7 +187,7 @@ func runMockAgentAtAddr(t *testing.T, addr string) *mockAgent {
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
 	agentPort, _ := strconv.Atoi(agentPortStr)
 
-	ma.port = uint16(agentPort)
+	ma.port = int(agentPort)
 	ma.stopFunc = deferFunc
 
 	return ma

--- a/ocagent.go
+++ b/ocagent.go
@@ -47,7 +47,7 @@ type Exporter struct {
 	mu              sync.RWMutex
 	started         bool
 	stopped         bool
-	agentPort       uint16
+	agentPort       int
 	agentAddress    string
 	serviceName     string
 	canDialInsecure bool

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -279,7 +279,7 @@ func TestNewExporter_agentOnBadConnection(t *testing.T) {
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
 	agentPort, _ := strconv.Atoi(agentPortStr)
 
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(uint16(agentPort)))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(agentPort))
 	if err == nil {
 		t.Fatal("Surprisingly connected to an unavailable non-gRPC connection")
 	}

--- a/options.go
+++ b/options.go
@@ -46,7 +46,7 @@ func WithInsecure() ExporterOption { return new(insecureGrpcConnection) }
 
 // WithPort allows one to override the port that the exporter will
 // connect to the agent on, instead of using DefaultAgentPort.
-func WithPort(port uint16) ExporterOption {
+func WithPort(port int) ExporterOption {
 	return portSetter(port)
 }
 

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@
 package ocagent
 
 const (
-	DefaultAgentPort uint16 = 55678
+	DefaultAgentPort int    = 55678
 	DefaultAgentHost string = "localhost"
 )
 
@@ -23,10 +23,10 @@ type ExporterOption interface {
 	withExporter(e *Exporter)
 }
 
-type portSetter uint16
+type portSetter int
 
 func (ps portSetter) withExporter(e *Exporter) {
-	e.agentPort = uint16(ps)
+	e.agentPort = int(ps)
 }
 
 var _ ExporterOption = (*portSetter)(nil)


### PR DESCRIPTION
Fixes https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/issues/21.