### PR TITLE
all: remove WithPort in favour of only using the WithAddress option

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -49,6 +49,7 @@ func TestExportsUnderLoad_issue13(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not parse port from agent address: %v", err)
 	}
+	agentAddr := fmt.Sprintf("localhost:%d", agentPort)
 
 	// Then create the frontend HTTP server's listener which
 	// will be used to generate tertiary spans that
@@ -73,7 +74,7 @@ func TestExportsUnderLoad_issue13(t *testing.T) {
 	exporter, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 		ocagent.WithServiceName("go-app"),
-		ocagent.WithPort(agentPort))
+		ocagent.WithAddress(agentAddr))
 	if err != nil {
 		t.Fatalf("Failed to create the agent exporter: %v", err)
 	}

--- a/mock_agent_test.go
+++ b/mock_agent_test.go
@@ -17,7 +17,6 @@ package ocagent_test
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -46,7 +45,7 @@ type mockAgent struct {
 	configsToSend          chan *agenttracepb.UpdatedLibraryConfig
 	closeConfigsToSendOnce sync.Once
 
-	port     uint16
+	address  string
 	stopFunc func() error
 	stopOnce sync.Once
 }
@@ -185,9 +184,8 @@ func runMockAgentAtAddr(t *testing.T, addr string) *mockAgent {
 	}
 
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
-	agentPort, _ := strconv.Atoi(agentPortStr)
 
-	ma.port = uint16(agentPort)
+	ma.address = "localhost:" + agentPortStr
 	ma.stopFunc = deferFunc
 
 	return ma

--- a/ocagent.go
+++ b/ocagent.go
@@ -47,7 +47,6 @@ type Exporter struct {
 	mu              sync.RWMutex
 	started         bool
 	stopped         bool
-	agentPort       uint16
 	agentAddress    string
 	serviceName     string
 	canDialInsecure bool
@@ -76,9 +75,6 @@ func NewUnstartedExporter(opts ...ExporterOption) (*Exporter, error) {
 	e := new(Exporter)
 	for _, opt := range opts {
 		opt.withExporter(e)
-	}
-	if e.agentPort <= 0 {
-		e.agentPort = DefaultAgentPort
 	}
 	traceBundler := bundler.NewBundler((*trace.SpanData)(nil), func(bundle interface{}) {
 		e.uploadTraces(bundle.([]*trace.SpanData))
@@ -123,11 +119,7 @@ func (ae *Exporter) prepareAgentAddress() string {
 	if ae.agentAddress != "" {
 		return ae.agentAddress
 	}
-	port := DefaultAgentPort
-	if ae.agentPort > 0 {
-		port = ae.agentPort
-	}
-	return fmt.Sprintf("%s:%d", DefaultAgentHost, port)
+	return fmt.Sprintf("%s:%d", DefaultAgentHost, DefaultAgentPort)
 }
 
 func (ae *Exporter) doStartLocked() error {

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	defer ma.stop()
 
 	serviceName := "endToEnd_test"
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port), ocagent.WithServiceName(serviceName))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address), ocagent.WithServiceName(serviceName))
 	if err != nil {
 		t.Fatalf("Failed to create a new agent exporter: %v", err)
 	}
@@ -209,7 +208,7 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 	ma := runMockAgent(t)
 	defer ma.stop()
 
-	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port))
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address))
 	if err != nil {
 		t.Fatal("Surprisingly connected with a bad port")
 	}
@@ -233,7 +232,7 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 
 func TestNewExporter_agentConnectionDiesInMidst(t *testing.T) {
 	ma := runMockAgent(t)
-	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithPort(ma.port))
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address))
 	if err != nil {
 		t.Fatal("Surprisingly connected with a bad port")
 	}
@@ -277,9 +276,9 @@ func TestNewExporter_agentOnBadConnection(t *testing.T) {
 	}()
 
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
-	agentPort, _ := strconv.Atoi(agentPortStr)
 
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(uint16(agentPort)))
+	address := fmt.Sprintf("localhost:%s", agentPortStr)
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(address))
 	if err == nil {
 		t.Fatal("Surprisingly connected to an unavailable non-gRPC connection")
 	}
@@ -292,8 +291,7 @@ func TestNewExporter_withAddress(t *testing.T) {
 	ma := runMockAgent(t)
 	defer ma.stop()
 
-	addr := fmt.Sprintf("localhost:%d", ma.port)
-	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(addr))
+	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address))
 	if err != nil {
 		t.Fatal("Surprisingly connected with a bad port")
 	}

--- a/options.go
+++ b/options.go
@@ -23,14 +23,6 @@ type ExporterOption interface {
 	withExporter(e *Exporter)
 }
 
-type portSetter uint16
-
-func (ps portSetter) withExporter(e *Exporter) {
-	e.agentPort = uint16(ps)
-}
-
-var _ ExporterOption = (*portSetter)(nil)
-
 type insecureGrpcConnection int
 
 var _ ExporterOption = (*insecureGrpcConnection)(nil)
@@ -43,12 +35,6 @@ func (igc *insecureGrpcConnection) withExporter(e *Exporter) {
 // just like grpc.WithInsecure() https://godoc.org/google.golang.org/grpc#WithInsecure
 // does. Note, by default, client security is required unless WithInsecure is used.
 func WithInsecure() ExporterOption { return new(insecureGrpcConnection) }
-
-// WithPort allows one to override the port that the exporter will
-// connect to the agent on, instead of using DefaultAgentPort.
-func WithPort(port uint16) ExporterOption {
-	return portSetter(port)
-}
 
 type addressSetter string
 

--- a/transform_spans_test.go
+++ b/transform_spans_test.go
@@ -35,7 +35,7 @@ func TestOCSpanToProtoSpan_endToEnd(t *testing.T) {
 	defer agent.stop()
 
 	serviceName := "spanTranslation"
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithPort(agent.port), ocagent.WithServiceName(serviceName))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(agent.address), ocagent.WithServiceName(serviceName))
 	if err != nil {
 		t.Fatalf("Failed to create a new agent exporter: %v", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/issues/22.