### PR TITLE
perform indefinite background reconnection attempts

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,94 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocagent
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	sDisconnected int32 = 5 + iota
+	sConnected
+)
+
+func (ae *Exporter) setStateDisconnected() {
+	atomic.StoreInt32(&ae.connectionState, sDisconnected)
+	ae.disconnectedCh <- true
+}
+
+func (ae *Exporter) setStateConnected() {
+	atomic.StoreInt32(&ae.connectionState, sConnected)
+}
+
+func (ae *Exporter) connected() bool {
+	return atomic.LoadInt32(&ae.connectionState) == sConnected
+}
+
+const defaultConnReattemptPeriod = 800 * time.Millisecond
+
+func (ae *Exporter) indefiniteBackgroundConnection() error {
+	defer func() {
+		ae.backgroundConnectionDoneCh <- true
+	}()
+
+	connReattemptPeriod := ae.reconnectionPeriod
+	if connReattemptPeriod <= 0 {
+		connReattemptPeriod = defaultConnReattemptPeriod
+	}
+
+	// No strong seeding required, nano time can
+	// already help with pseudo uniqueness.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano() + rand.Int63n(1024)))
+
+	// maxJitter: 1 + (70% of the connectionReattemptPeriod)
+	maxJitter := int64(1 + 0.7*float64(connReattemptPeriod))
+
+	for {
+		// Otherwise these will be the normal scenarios to enable
+		// reconnections if we trip out.
+		// 1. If we've stopped, return entirely
+		// 2. Otherwise block until we are disconnected, and
+		//    then retry connecting
+		select {
+		case <-ae.stopCh:
+			return errStopped
+
+		case <-ae.disconnectedCh:
+			// Normal scenario that we'll wait for
+		}
+
+		if err := ae.connect(); err == nil {
+			ae.setStateConnected()
+		} else {
+			ae.setStateDisconnected()
+		}
+
+		// Apply some jitter to avoid lockstep retrials of other
+		// agent-exporters. Lockstep retrials could result in an
+		// innocent DDOS, by clogging the machine's resources and network.
+		jitter := time.Duration(rng.Int63n(maxJitter))
+		<-time.After(connReattemptPeriod + jitter)
+	}
+}
+
+func (ae *Exporter) connect() error {
+	cc, err := ae.dialToAgent()
+	if err != nil {
+		return err
+	}
+	return ae.enableConnectionStreams(cc)
+}

--- a/connection.go
+++ b/connection.go
@@ -38,7 +38,7 @@ func (ae *Exporter) connected() bool {
 	return atomic.LoadInt32(&ae.connectionState) == sConnected
 }
 
-const defaultConnReattemptPeriod = 800 * time.Millisecond
+const defaultConnReattemptPeriod = 5000 * time.Millisecond
 
 func (ae *Exporter) indefiniteBackgroundConnection() error {
 	defer func() {

--- a/connection.go
+++ b/connection.go
@@ -38,7 +38,7 @@ func (ae *Exporter) connected() bool {
 	return atomic.LoadInt32(&ae.connectionState) == sConnected
 }
 
-const defaultConnReattemptPeriod = 5000 * time.Millisecond
+const defaultConnReattemptPeriod = 10 * time.Second
 
 func (ae *Exporter) indefiniteBackgroundConnection() error {
 	defer func() {

--- a/load_test.go
+++ b/load_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -74,6 +75,7 @@ func TestExportsUnderLoad_issue13(t *testing.T) {
 	exporter, err := ocagent.NewExporter(
 		ocagent.WithInsecure(),
 		ocagent.WithServiceName("go-app"),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
 		ocagent.WithAddress(agentAddr))
 	if err != nil {
 		t.Fatalf("Failed to create the agent exporter: %v", err)

--- a/ocagent.go
+++ b/ocagent.go
@@ -43,17 +43,26 @@ func init() {
 var _ trace.Exporter = (*Exporter)(nil)
 
 type Exporter struct {
+	connectionState int32
+
 	// mu protects the non-atomic and non-channel variables
-	mu              sync.RWMutex
-	started         bool
-	stopped         bool
-	agentAddress    string
-	serviceName     string
-	canDialInsecure bool
-	traceSvcClient  agenttracepb.TraceServiceClient
-	traceExporter   agenttracepb.TraceService_ExportClient
-	nodeInfo        *agentcommonpb.Node
-	grpcClientConn  *grpc.ClientConn
+	mu                 sync.RWMutex
+	started            bool
+	stopped            bool
+	agentAddress       string
+	serviceName        string
+	canDialInsecure    bool
+	traceSvcClient     agenttracepb.TraceServiceClient
+	traceExporter      agenttracepb.TraceService_ExportClient
+	nodeInfo           *agentcommonpb.Node
+	grpcClientConn     *grpc.ClientConn
+	reconnectionPeriod time.Duration
+
+	startOnce      sync.Once
+	stopCh         chan bool
+	disconnectedCh chan bool
+
+	backgroundConnectionDoneCh chan bool
 
 	traceBundler *bundler.Bundler
 }
@@ -83,6 +92,7 @@ func NewUnstartedExporter(opts ...ExporterOption) (*Exporter, error) {
 	traceBundler.BundleCountThreshold = spanDataBufferSize
 	e.traceBundler = traceBundler
 	e.nodeInfo = createNodeInfo(e.serviceName)
+
 	return e, nil
 }
 
@@ -91,26 +101,32 @@ const (
 	maxInitialTracesRetries = 10
 )
 
+var (
+	errAlreadyStarted = errors.New("already started")
+	errStopped        = errors.New("stopped")
+)
+
 // Start dials to the agent, establishing a connection to it. It also
 // initiates the Config and Trace services by sending over the initial
-// messages that consist of the node identifier. Start performs a best case
-// attempt to try to send the initial messages, by applying exponential
-// backoff at most 10 times.
+// messages that consist of the node identifier. Start invokes a background
+// connector that will reattempt connections to the agent periodically
+// if the connection dies.
 func (ae *Exporter) Start() error {
-	ae.mu.Lock()
-	defer ae.mu.Unlock()
+	var err = errAlreadyStarted
+	ae.startOnce.Do(func() {
+		ae.mu.Lock()
+		defer ae.mu.Unlock()
 
-	err := ae.doStartLocked()
-	if err == nil {
 		ae.started = true
-		return nil
-	}
+		ae.disconnectedCh = make(chan bool, 1)
+		ae.stopCh = make(chan bool)
+		ae.backgroundConnectionDoneCh = make(chan bool)
 
-	// Otherwise we have an error and should clean up to avoid leaking resources.
-	ae.started = false
-	if ae.grpcClientConn != nil {
-		ae.grpcClientConn.Close()
-	}
+		ae.setStateDisconnected()
+		go ae.indefiniteBackgroundConnection()
+
+		err = nil
+	})
 
 	return err
 }
@@ -122,17 +138,23 @@ func (ae *Exporter) prepareAgentAddress() string {
 	return fmt.Sprintf("%s:%d", DefaultAgentHost, DefaultAgentPort)
 }
 
-func (ae *Exporter) doStartLocked() error {
-	if ae.started {
-		return nil
+func (ae *Exporter) enableConnectionStreams(cc *grpc.ClientConn) error {
+	ae.mu.RLock()
+	started := ae.started
+	nodeInfo := ae.nodeInfo
+	ae.mu.RUnlock()
+
+	if !started {
+		return errNotStarted
 	}
 
-	// Now start it
-	cc, err := ae.dialToAgent()
-	if err != nil {
-		return err
+	ae.mu.Lock()
+	// If the previous clientConn was non-nil, close it
+	if ae.grpcClientConn != nil {
+		_ = ae.grpcClientConn.Close()
 	}
 	ae.grpcClientConn = cc
+	ae.mu.Unlock()
 
 	// Initiate the trace service by sending over node identifier info.
 	traceSvcClient := agenttracepb.NewTraceServiceClient(cc)
@@ -141,11 +163,8 @@ func (ae *Exporter) doStartLocked() error {
 		return fmt.Errorf("Exporter.Start:: TraceServiceClient: %v", err)
 	}
 
-	firstTraceMessage := &agenttracepb.ExportTraceServiceRequest{Node: ae.nodeInfo}
-	err = nTriesWithExponentialBackoff(maxInitialTracesRetries, 200*time.Microsecond, func() error {
-		return traceExporter.Send(firstTraceMessage)
-	})
-	if err != nil {
+	firstTraceMessage := &agenttracepb.ExportTraceServiceRequest{Node: nodeInfo}
+	if err := traceExporter.Send(firstTraceMessage); err != nil {
 		return fmt.Errorf("Exporter.Start:: Failed to initiate the Config service: %v", err)
 	}
 	ae.traceExporter = traceExporter
@@ -155,11 +174,8 @@ func (ae *Exporter) doStartLocked() error {
 	if err != nil {
 		return fmt.Errorf("Exporter.Start:: ConfigStream: %v", err)
 	}
-	firstCfgMessage := &agenttracepb.CurrentLibraryConfig{Node: ae.nodeInfo}
-	err = nTriesWithExponentialBackoff(maxInitialConfigRetries, 200*time.Microsecond, func() error {
-		return configStream.Send(firstCfgMessage)
-	})
-	if err != nil {
+	firstCfgMessage := &agenttracepb.CurrentLibraryConfig{Node: nodeInfo}
+	if err := configStream.Send(firstCfgMessage); err != nil {
 		return fmt.Errorf("Exporter.Start:: Failed to initiate the Config service: %v", err)
 	}
 
@@ -170,29 +186,13 @@ func (ae *Exporter) doStartLocked() error {
 	return nil
 }
 
-// dialToAgent performs a best case attempt to dial to the agent.
-// It retries failed dials with:
-//  * gRPC dialTimeout of 1s
-//  * exponential backoff, 5 times with a period of 50ms
-// hence in the worst case of (no agent actually available), it
-// will take at least:
-//      (5 * 1s) + ((1<<5)-1) * 0.05 s = 5s + 1.55s = 6.55s
 func (ae *Exporter) dialToAgent() (*grpc.ClientConn, error) {
 	addr := ae.prepareAgentAddress()
-	dialOpts := []grpc.DialOption{grpc.WithBlock()}
+	var dialOpts []grpc.DialOption
 	if ae.canDialInsecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	}
-
-	var cc *grpc.ClientConn
-	dialOpts = append(dialOpts, grpc.WithTimeout(1*time.Second))
-	dialBackoffWaitPeriod := 50 * time.Millisecond
-	err := nTriesWithExponentialBackoff(5, dialBackoffWaitPeriod, func() error {
-		var err error
-		cc, err = grpc.Dial(addr, dialOpts...)
-		return err
-	})
-	return cc, err
+	return grpc.Dial(addr, dialOpts...)
 }
 
 func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService_ConfigClient) error {
@@ -200,6 +200,7 @@ func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService
 		recv, err := configStream.Recv()
 		if err != nil {
 			// TODO: Check if this is a transient error or exponential backoff-able.
+			ae.setStateDisconnected()
 			return err
 		}
 		cfg := recv.Config
@@ -223,6 +224,7 @@ func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService
 		// Then finally send back to upstream the newly applied configuration
 		err = configStream.Send(&agenttracepb.CurrentLibraryConfig{Config: &tracepb.TraceConfig{Sampler: cfg.Sampler}})
 		if err != nil {
+			ae.setStateDisconnected()
 			return err
 		}
 	}
@@ -235,13 +237,16 @@ var (
 // Stop shuts down all the connections and resources
 // related to the exporter.
 func (ae *Exporter) Stop() error {
-	ae.mu.Lock()
-	defer ae.mu.Unlock()
+	ae.mu.RLock()
+	cc := ae.grpcClientConn
+	started := ae.started
+	stopped := ae.stopped
+	ae.mu.RUnlock()
 
-	if !ae.started {
+	if !started {
 		return errNotStarted
 	}
-	if ae.stopped {
+	if stopped {
 		// TODO: tell the user that we've already stopped, so perhaps a sentinel error?
 		return nil
 	}
@@ -250,13 +255,19 @@ func (ae *Exporter) Stop() error {
 
 	// Now close the underlying gRPC connection.
 	var err error
-	if ae.grpcClientConn != nil {
-		err = ae.grpcClientConn.Close()
+	if cc != nil {
+		err = cc.Close()
 	}
 
 	// At this point we can change the state variables: started and stopped
+	ae.mu.Lock()
 	ae.started = false
 	ae.stopped = true
+	ae.mu.Unlock()
+	close(ae.stopCh)
+
+	// Ensure that the backgroundConnector returns
+	<-ae.backgroundConnectionDoneCh
 
 	return err
 }
@@ -268,9 +279,9 @@ func (ae *Exporter) ExportSpan(sd *trace.SpanData) {
 	_ = ae.traceBundler.Add(sd, 1)
 }
 
-func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
+func ocSpanDataToPbSpans(sdl []*trace.SpanData) []*tracepb.Span {
 	if len(sdl) == 0 {
-		return
+		return nil
 	}
 	protoSpans := make([]*tracepb.Span, 0, len(sdl))
 	for _, sd := range sdl {
@@ -278,11 +289,24 @@ func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
 			protoSpans = append(protoSpans, ocSpanToProtoSpan(sd))
 		}
 	}
+	return protoSpans
+}
 
-	if len(protoSpans) > 0 {
-		_ = ae.traceExporter.Send(&agenttracepb.ExportTraceServiceRequest{
-			Spans: protoSpans,
-		})
+func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
+	select {
+	case <-ae.stopCh:
+		return
+
+	default:
+		protoSpans := ocSpanDataToPbSpans(sdl)
+		if len(protoSpans) > 0 && ae.connected() {
+			err := ae.traceExporter.Send(&agenttracepb.ExportTraceServiceRequest{
+				Spans: protoSpans,
+			})
+			if err != nil {
+				ae.setStateDisconnected()
+			}
+		}
 	}
 }
 

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -36,7 +36,10 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	defer ma.stop()
 
 	serviceName := "endToEnd_test"
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address), ocagent.WithServiceName(serviceName))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(),
+		ocagent.WithAddress(ma.address),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
+		ocagent.WithServiceName(serviceName))
 	if err != nil {
 		t.Fatalf("Failed to create a new agent exporter: %v", err)
 	}
@@ -208,7 +211,9 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 	ma := runMockAgent(t)
 	defer ma.stop()
 
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
+		ocagent.WithAddress(ma.address))
 	if err != nil {
 		t.Fatal("Surprisingly connected with a bad port")
 	}
@@ -301,7 +306,9 @@ func TestNewExporter_agentOnBadConnection(t *testing.T) {
 	_, agentPortStr, _ := net.SplitHostPort(ln.Addr().String())
 
 	address := fmt.Sprintf("localhost:%s", agentPortStr)
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(address))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
+		ocagent.WithAddress(address))
 	if err != nil {
 		t.Fatalf("Despite an indefinite background reconnection, got error: %v", err)
 	}
@@ -312,7 +319,10 @@ func TestNewExporter_withAddress(t *testing.T) {
 	ma := runMockAgent(t)
 	defer ma.stop()
 
-	exp, err := ocagent.NewUnstartedExporter(ocagent.WithInsecure(), ocagent.WithAddress(ma.address))
+	exp, err := ocagent.NewUnstartedExporter(
+		ocagent.WithInsecure(),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
+		ocagent.WithAddress(ma.address))
 	if err != nil {
 		t.Fatal("Surprisingly connected with a bad port")
 	}

--- a/options.go
+++ b/options.go
@@ -14,6 +14,8 @@
 
 package ocagent
 
+import "time"
+
 const (
 	DefaultAgentPort uint16 = 55678
 	DefaultAgentHost string = "localhost"
@@ -63,4 +65,14 @@ var _ ExporterOption = (*serviceNameSetter)(nil)
 // that the exporter will report to the agent.
 func WithServiceName(serviceName string) ExporterOption {
 	return serviceNameSetter(serviceName)
+}
+
+type reconnectionPeriod time.Duration
+
+func (rp reconnectionPeriod) withExporter(e *Exporter) {
+	e.reconnectionPeriod = time.Duration(rp)
+}
+
+func WithReconnectionPeriod(rp time.Duration) ExporterOption {
+	return reconnectionPeriod(rp)
 }

--- a/transform_spans_test.go
+++ b/transform_spans_test.go
@@ -35,7 +35,10 @@ func TestOCSpanToProtoSpan_endToEnd(t *testing.T) {
 	defer agent.stop()
 
 	serviceName := "spanTranslation"
-	exp, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithAddress(agent.address), ocagent.WithServiceName(serviceName))
+	exp, err := ocagent.NewExporter(ocagent.WithInsecure(),
+		ocagent.WithAddress(agent.address),
+		ocagent.WithReconnectionPeriod(50*time.Millisecond),
+		ocagent.WithServiceName(serviceName))
 	if err != nil {
 		t.Fatalf("Failed to create a new agent exporter: %v", err)
 	}


### PR DESCRIPTION
Perform an indefinite background redial on failed connections
to ensure that this exporter can reconnect to the upstream
OpenCensus interceptor/agent.

This change allows environments that don't yet have the agent
deployed to start using this exporter and gradually roll-out
the agent. It helps trivial situations like an application
starting before the agent: of which it shouldn't crash
and fail to start running -- all the exported spans before
the agent is ready for connections, or at least if the
span buffer is full, will be discarded.

Added tests to ensure that this works and lock-in that
behavior.

Fixes #18