### PR TITLE
fixup: remove useless traceSvcClient in Exporter struct

### DIFF
--- a/ocagent.go
+++ b/ocagent.go
@@ -52,7 +52,6 @@ type Exporter struct {
 	agentAddress       string
 	serviceName        string
 	canDialInsecure    bool
-	traceSvcClient     agenttracepb.TraceServiceClient
 	traceExporter      agenttracepb.TraceService_ExportClient
 	nodeInfo           *agentcommonpb.Node
 	grpcClientConn     *grpc.ClientConn


### PR DESCRIPTION
According to codes between [ocagent.go#L160](https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/blob/master/ocagent.go#L160) and [ocagent.go#L176](https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/blob/master/ocagent.go#L176), I think `traceSvcClient` in `Exporter` struct is useless. 

@odeke-em PTAL