### PR TITLE
Add batched span with node export functionality to oc exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module contrib.go.opencensus.io/exporter/ocagent
 
 require (
-	github.com/census-instrumentation/opencensus-proto v0.1.0
+	github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8 // this is to match the version used in census-instrumentation/opencensus-service
 	github.com/golang/protobuf v1.2.0
 	go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b
 	google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf

--- a/ocagent.go
+++ b/ocagent.go
@@ -291,8 +291,6 @@ func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService
 	}
 }
 
-var ()
-
 // Stop shuts down all the connections and resources
 // related to the exporter.
 func (ae *Exporter) Stop() error {

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -73,7 +73,7 @@ func TestNewExporter_endToEnd(t *testing.T) {
 		name := tracepb.TruncatableString{Value: "AlwaysSample"}
 		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
 	}
-	exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+	_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
@@ -122,7 +122,7 @@ func TestNewExporter_endToEnd(t *testing.T) {
 		name := tracepb.TruncatableString{Value: "ProbabilitySampler-100%"}
 		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
 	}
-	exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+	_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
@@ -296,7 +296,7 @@ func TestNewExporter_agentConnectionDiesThenReconnects(t *testing.T) {
 			name := tracepb.TruncatableString{Value: "Resurrected"}
 			batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
 		}
-		exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+		_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 		<-time.After(reconnectionPeriod * 3)
 		nmaSpans := nma.getSpans()

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -66,6 +66,15 @@ func TestNewExporter_endToEnd(t *testing.T) {
 		span.Annotatef([]trace.Attribute{trace.Int64Attribute("i", int64(i))}, "Annotation")
 		span.End()
 	}
+
+	m := 4
+	batchedSpans := make([]*tracepb.Span, 0, m)
+	for i := 0; i < m; i++ {
+		name := tracepb.TruncatableString{Value: "AlwaysSample"}
+		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+	}
+	exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
 
@@ -106,6 +115,15 @@ func TestNewExporter_endToEnd(t *testing.T) {
 		span.Annotatef([]trace.Attribute{trace.BoolAttribute("odd", i&1 == 1)}, "Annotation")
 		span.End()
 	}
+
+	m = 3
+	batchedSpans = make([]*tracepb.Span, 0, m)
+	for i := 0; i < m; i++ {
+		name := tracepb.TruncatableString{Value: "ProbabilitySampler-100%"}
+		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+	}
+	exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
 
@@ -154,10 +172,10 @@ func TestNewExporter_endToEnd(t *testing.T) {
 		t.Errorf("ReceivedConfigs: got %d want %d", g, w)
 	}
 
-	// Expecting 7 spanData that were sampled, given that
+	// Expecting 14 spanData that were sampled, given that
 	// two of the trace configs pushed down to the client
 	// were {NeverSample, ProbabilitySampler(0.0)}
-	if g, w := len(spans), 7; g != w {
+	if g, w := len(spans), 14; g != w {
 		t.Errorf("Spans: got %d want %d", g, w)
 	}
 
@@ -272,11 +290,18 @@ func TestNewExporter_agentConnectionDiesThenReconnects(t *testing.T) {
 			exp.ExportSpan(&trace.SpanData{Name: "Resurrected"})
 		}
 		exp.Flush()
-		<-time.After(reconnectionPeriod * 3)
+		m := 10
+		batchedSpans := make([]*tracepb.Span, 0, m)
+		for i := 0; i < m; i++ {
+			name := tracepb.TruncatableString{Value: "Resurrected"}
+			batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+		}
+		exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
+		<-time.After(reconnectionPeriod * 3)
 		nmaSpans := nma.getSpans()
 		// Expecting 10 spanData that were sampled, given that
-		if g, w := len(nmaSpans), n; g != w {
+		if g, w := len(nmaSpans), n+m; g != w {
 			t.Errorf("Round #%d: Connected agent: spans: got %d want %d", j, g, w)
 		}
 

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -70,10 +70,10 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	m := 4
 	batchedSpans := make([]*tracepb.Span, 0, m)
 	for i := 0; i < m; i++ {
-		name := tracepb.TruncatableString{Value: "AlwaysSample"}
-		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+		name := &tracepb.TruncatableString{Value: "AlwaysSample"}
+		batchedSpans = append(batchedSpans, &tracepb.Span{Name: name})
 	}
-	_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+	_ = exp.ExportTraceServiceRequest(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
@@ -119,10 +119,10 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	m = 3
 	batchedSpans = make([]*tracepb.Span, 0, m)
 	for i := 0; i < m; i++ {
-		name := tracepb.TruncatableString{Value: "ProbabilitySampler-100%"}
-		batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+		name := &tracepb.TruncatableString{Value: "ProbabilitySampler-100%"}
+		batchedSpans = append(batchedSpans, &tracepb.Span{Name: name})
 	}
-	_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+	_ = exp.ExportTraceServiceRequest(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 	<-time.After(10 * time.Millisecond)
 	exp.Flush()
@@ -293,10 +293,10 @@ func TestNewExporter_agentConnectionDiesThenReconnects(t *testing.T) {
 		m := 10
 		batchedSpans := make([]*tracepb.Span, 0, m)
 		for i := 0; i < m; i++ {
-			name := tracepb.TruncatableString{Value: "Resurrected"}
-			batchedSpans = append(batchedSpans, &tracepb.Span{Name: &name})
+			name := &tracepb.TruncatableString{Value: "Resurrected"}
+			batchedSpans = append(batchedSpans, &tracepb.Span{Name: name})
 		}
-		_ = exp.ExportSpanBatch(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
+		_ = exp.ExportTraceServiceRequest(&agenttracepb.ExportTraceServiceRequest{Spans: batchedSpans})
 
 		<-time.After(reconnectionPeriod * 3)
 		nmaSpans := nma.getSpans()


### PR DESCRIPTION
In order to ensure that different nodes can be sent from the ocagent, a
new function was added that takes node information along with a batch of
spans.

Testing Done: unit test