### PR TITLE
Add compression option to oc exporter

### DIFF
--- a/ocagent.go
+++ b/ocagent.go
@@ -66,7 +66,7 @@ type Exporter struct {
 	grpcClientConn     *grpc.ClientConn
 	reconnectionPeriod time.Duration
 	resource           *resourcepb.Resource
-	compressor         *string
+	compressor         string
 
 	startOnce      sync.Once
 	stopCh         chan bool
@@ -254,8 +254,8 @@ func (ae *Exporter) dialToAgent() (*grpc.ClientConn, error) {
 	if ae.canDialInsecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	}
-	if ae.compressor != nil {
-		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(*ae.compressor)))
+	if ae.compressor != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(ae.compressor)))
 	}
 	return grpc.Dial(addr, dialOpts...)
 }

--- a/ocagent.go
+++ b/ocagent.go
@@ -98,7 +98,7 @@ const spanDataBufferSize = 300
 func NewUnstartedExporter(opts ...ExporterOption) (*Exporter, error) {
 	e := new(Exporter)
 	for _, opt := range opts {
-		opt(e)
+		opt.withExporter(e)
 	}
 	traceBundler := bundler.NewBundler((*trace.SpanData)(nil), func(bundle interface{}) {
 		e.uploadTraces(bundle.([]*trace.SpanData))

--- a/options.go
+++ b/options.go
@@ -64,6 +64,6 @@ func WithReconnectionPeriod(rp time.Duration) ExporterOption {
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func UseCompressor(compressorName string) ExporterOption {
 	return func(e *Exporter) {
-		e.compressor = &compressorName
+		e.compressor = compressorName
 	}
 }

--- a/viewdata_to_metrics_test.go
+++ b/viewdata_to_metrics_test.go
@@ -55,9 +55,11 @@ func TestExportMetrics_conversionFromViewData(t *testing.T) {
 	}()
 
 	reconnectionPeriod := 2 * time.Millisecond
-	ocexp, err := NewExporter(WithInsecure(),
+	ocexp, err := NewExporter(
+		WithInsecure(),
 		WithAddress(":"+agentPortStr),
-		WithReconnectionPeriod(reconnectionPeriod))
+		WithReconnectionPeriod(reconnectionPeriod),
+	)
 	if err != nil {
 		t.Fatalf("Failed to create the ocagent exporter: %v", err)
 	}


### PR DESCRIPTION
Adds the ability to optionally compress gRPC requests via DefaultCallOptions. 