### PR TITLE
Add with headers option to agent exporter

### DIFF
--- a/ocagent.go
+++ b/ocagent.go
@@ -68,6 +68,7 @@ type Exporter struct {
 	reconnectionPeriod time.Duration
 	resource           *resourcepb.Resource
 	compressor         string
+	headers            map[string]string
 
 	startOnce      sync.Once
 	stopCh         chan bool

--- a/ocagent.go
+++ b/ocagent.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/api/support/bundler"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"go.opencensus.io/resource"
 	"go.opencensus.io/stats/view"
@@ -191,7 +192,11 @@ func (ae *Exporter) enableConnectionStreams(cc *grpc.ClientConn) error {
 func (ae *Exporter) createTraceServiceConnection(cc *grpc.ClientConn, node *commonpb.Node) error {
 	// Initiate the trace service by sending over node identifier info.
 	traceSvcClient := agenttracepb.NewTraceServiceClient(cc)
-	traceExporter, err := traceSvcClient.Export(context.Background())
+	ctx := context.Background()
+	if len(ae.headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(ae.headers))
+	}
+	traceExporter, err := traceSvcClient.Export(ctx)
 	if err != nil {
 		return fmt.Errorf("Exporter.Start:: TraceServiceClient: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -91,3 +91,15 @@ func (c compressorSetter) withExporter(e *Exporter) {
 func UseCompressor(compressorName string) ExporterOption {
 	return compressorSetter(compressorName)
 }
+
+type headerSetter map[string]string
+
+func (h headerSetter) withExporter(e *Exporter) {
+	e.headers = map[string]string(h)
+}
+
+// WithHeaders will send the provided headers when the gRPC stream connection
+// is instantiated
+func WithHeaders(headers map[string]string) ExporterOption {
+	return headerSetter(headers)
+}


### PR DESCRIPTION
Adds the ability to send headers when first connecting to the TraceServiceClient stream