### PR TITLE
Add headers to ClientConn dial

### DIFF
--- a/ocagent.go
+++ b/ocagent.go
@@ -268,7 +268,12 @@ func (ae *Exporter) dialToAgent() (*grpc.ClientConn, error) {
 	if ae.compressor != "" {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(ae.compressor)))
 	}
-	return grpc.Dial(addr, dialOpts...)
+
+	ctx := context.Background()
+	if len(ae.headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(ae.headers))
+	}
+	return grpc.DialContext(ctx, addr, dialOpts...)
 }
 
 func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService_ConfigClient) error {


### PR DESCRIPTION
Currently we only send metadata (headers) on each export request, and not on the initial dial. If headers are used for routing or something authentication related, the initial connect won't be sent with headers, so it will fail. 