### PR TITLE
go.mod: update to OpenCensus-Proto v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module contrib.go.opencensus.io/exporter/ocagent
 
 require (
-	github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8 // this is to match the version used in census-instrumentation/opencensus-service
-	github.com/golang/protobuf v1.2.0
+	github.com/census-instrumentation/opencensus-proto v0.2.0 // this is to match the version used in census-instrumentation/opencensus-service
+	github.com/golang/protobuf v1.3.0
 	go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b
 	google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf
 	google.golang.org/grpc v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/census-instrumentation/opencensus-proto v0.0.1 h1:4v5I+ax5jCmwTYVaWQacX8ZSxvUZemBX4UwBGSkDeoA=
-github.com/census-instrumentation/opencensus-proto v0.0.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/census-instrumentation/opencensus-proto v0.0.2-0.20180913191712-f303ae3f8d6a h1:t88pXOTS5K+pjfuhTOcul6sdC4khgqB8ukyfbe62Zxo=
-github.com/census-instrumentation/opencensus-proto v0.0.2-0.20180913191712-f303ae3f8d6a/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/census-instrumentation/opencensus-proto v0.1.0 h1:VwZ9smxzX8u14/125wHIX7ARV+YhR+L4JADswwxWK0Y=
-github.com/census-instrumentation/opencensus-proto v0.1.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
+github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -14,6 +10,9 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.0 h1:kbxbvI4Un1LUWKxufD+BiE6AEExYYgkQLQmLFqA1LFk=
+github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -23,10 +22,6 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-go.opencensus.io v0.17.0 h1:2Cu88MYg+1LU+WVD+NWwYhyP0kKgRlN9QjWGaX0jKTE=
-go.opencensus.io v0.17.0/go.mod h1:mp1VrMQxhlqqDpKvH4UcQUa4YwlzNmymAjPrDdfxNpI=
-go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
-go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b h1:6ayHMBPtdP3jNuk+Sfhso+PTB7ZJQ5E1FBo403m2H8w=
 go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -37,6 +32,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/ocagent.go
+++ b/ocagent.go
@@ -294,7 +294,7 @@ func (ae *Exporter) handleConfigStreaming(configStream agenttracepb.TraceService
 		if psamp := cfg.GetProbabilitySampler(); psamp != nil {
 			trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(psamp.SamplingProbability)})
 		} else if csamp := cfg.GetConstantSampler(); csamp != nil {
-			alwaysSample := csamp.Decision == true
+			alwaysSample := csamp.Decision == tracepb.ConstantSampler_ALWAYS_ON
 			if alwaysSample {
 				trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 			} else {

--- a/ocagent_test.go
+++ b/ocagent_test.go
@@ -54,7 +54,7 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
 		Config: &tracepb.TraceConfig{
 			Sampler: &tracepb.TraceConfig_ConstantSampler{
-				ConstantSampler: &tracepb.ConstantSampler{Decision: true}, // Always sample
+				ConstantSampler: &tracepb.ConstantSampler{Decision: tracepb.ConstantSampler_ALWAYS_ON}, // Always sample
 			},
 		},
 	}
@@ -82,7 +82,7 @@ func TestNewExporter_endToEnd(t *testing.T) {
 	ma.configsToSend <- &agenttracepb.UpdatedLibraryConfig{
 		Config: &tracepb.TraceConfig{
 			Sampler: &tracepb.TraceConfig_ConstantSampler{
-				ConstantSampler: &tracepb.ConstantSampler{Decision: false}, // Never sample
+				ConstantSampler: &tracepb.ConstantSampler{Decision: tracepb.ConstantSampler_ALWAYS_OFF}, // Never sample
 			},
 		},
 	}

--- a/transform_stats_to_metrics.go
+++ b/transform_stats_to_metrics.go
@@ -50,13 +50,13 @@ func viewDataToMetric(vd *view.Data) (*metricspb.Metric, error) {
 	}
 
 	metric := &metricspb.Metric{
-		Descriptor_: descriptor,
-		Timeseries:  timeseries,
+		MetricDescriptor: descriptor,
+		Timeseries:       timeseries,
 	}
 	return metric, nil
 }
 
-func viewToMetricDescriptor(v *view.View) (*metricspb.Metric_MetricDescriptor, error) {
+func viewToMetricDescriptor(v *view.View) (*metricspb.MetricDescriptor, error) {
 	if v == nil {
 		return nil, errNilView
 	}
@@ -64,14 +64,12 @@ func viewToMetricDescriptor(v *view.View) (*metricspb.Metric_MetricDescriptor, e
 		return nil, errNilMeasure
 	}
 
-	desc := &metricspb.Metric_MetricDescriptor{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:        stringOrCall(v.Name, v.Measure.Name),
-			Description: stringOrCall(v.Description, v.Measure.Description),
-			Unit:        v.Measure.Unit(),
-			Type:        aggregationToMetricDescriptorType(v),
-			LabelKeys:   tagKeysToLabelKeys(v.TagKeys),
-		},
+	desc := &metricspb.MetricDescriptor{
+		Name:        stringOrCall(v.Name, v.Measure.Name),
+		Description: stringOrCall(v.Description, v.Measure.Description),
+		Unit:        v.Measure.Unit(),
+		Type:        aggregationToMetricDescriptorType(v),
+		LabelKeys:   tagKeysToLabelKeys(v.TagKeys),
 	}
 	return desc, nil
 }

--- a/transform_stats_to_metrics_test.go
+++ b/transform_stats_to_metrics_test.go
@@ -112,16 +112,14 @@ func TestViewDataToMetrics_Distribution(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/latency",
-						Description: "latency of runners for a 100m dash",
-						Unit:        "ms", // Derived from the measure
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/latency",
+					Description: "latency of runners for a 100m dash",
+					Unit:        "ms", // Derived from the measure
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -281,17 +279,15 @@ func TestViewDataToMetrics_Distribution(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/fouls",
-						Description: "The number of fouls recorded",
-						Unit:        "1", // Derived from the measure
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-							{Key: "player_name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/fouls",
+					Description: "The number of fouls recorded",
+					Unit:        "1", // Derived from the measure
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
+						{Key: "player_name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -413,16 +409,14 @@ func TestViewDataToMetrics_LastValue(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/chronospeed",
-						Description: "the chronometer readings per referee",
-						Unit:        "ms",
-						Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/chronospeed",
+					Description: "the chronometer readings per referee",
+					Unit:        "ms",
+					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -529,16 +523,14 @@ func TestViewDataToMetrics_LastValue(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/latency",
-						Description: "latency of runners for a 100m dash",
-						Unit:        "ms", // Derived from the measure
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/latency",
+					Description: "latency of runners for a 100m dash",
+					Unit:        "ms", // Derived from the measure
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -695,16 +687,14 @@ func TestViewDataToMetrics_Count(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/counts",
-						Description: "count of runners for a 100m dash",
-						Unit:        "ms",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/counts",
+					Description: "count of runners for a 100m dash",
+					Unit:        "ms",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -783,17 +773,15 @@ func TestViewDataToMetrics_Count(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/fouls",
-						Description: "the number of fouls by players",
-						Unit:        "1",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-							{Key: "player_name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/fouls",
+					Description: "the number of fouls by players",
+					Unit:        "1",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
+						{Key: "player_name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -885,16 +873,14 @@ func TestViewDataToMetrics_Sum(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/latency",
-						Description: "speed of the various runners",
-						Unit:        "ms",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/latency",
+					Description: "speed of the various runners",
+					Unit:        "ms",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -973,17 +959,15 @@ func TestViewDataToMetrics_Sum(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/fouls",
-						Description: "the number of fouls by players",
-						Unit:        "1",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-							{Key: "player_name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/fouls",
+					Description: "the number of fouls by players",
+					Unit:        "1",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
+						{Key: "player_name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -1065,17 +1049,15 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/latency",
-						Description: "speed of the various runners",
-						Unit:        "ms",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-							{Key: "player_name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/latency",
+					Description: "speed of the various runners",
+					Unit:        "ms",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
+						{Key: "player_name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{
@@ -1127,17 +1109,15 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 				},
 			},
 			want: &metricspb.Metric{
-				Descriptor_: &metricspb.Metric_MetricDescriptor{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        "ocagent.io/fouls",
-						Description: "the number of fouls by players",
-						Unit:        "1",
-						Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-						LabelKeys: []*metricspb.LabelKey{
-							{Key: "field"},
-							{Key: "name"},
-							{Key: "player_name"},
-						},
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "ocagent.io/fouls",
+					Description: "the number of fouls by players",
+					Unit:        "1",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "field"},
+						{Key: "name"},
+						{Key: "player_name"},
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{

--- a/viewdata_to_metrics_test.go
+++ b/viewdata_to_metrics_test.go
@@ -108,14 +108,12 @@ func TestExportMetrics_conversionFromViewData(t *testing.T) {
 		{
 			Metrics: []*metricspb.Metric{
 				{
-					Descriptor_: &metricspb.Metric_MetricDescriptor{
-						MetricDescriptor: &metricspb.MetricDescriptor{
-							Name:        "ocagent.io/latency",
-							Description: "The latency of the various methods",
-							Unit:        "ms", // Derived from the measure
-							Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-							LabelKeys:   nil,
-						},
+					MetricDescriptor: &metricspb.MetricDescriptor{
+						Name:        "ocagent.io/latency",
+						Description: "The latency of the various methods",
+						Unit:        "ms", // Derived from the measure
+						Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+						LabelKeys:   nil,
 					},
 					Timeseries: []*metricspb.TimeSeries{
 						{


### PR DESCRIPTION
Updated to OpenCensus-Proto v0.2.0 but also
ran `go mod tidy` too for a clean-up of old
resources.