### PR TITLE
Test against both module on and off in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ script:
   - go build ./...                    # Ensure dependency updates don't break build
   - if [ -n "$(gofmt -s -l $GO_FILES)" ]; then echo "gofmt the following files:"; gofmt -s -l $GO_FILES; exit 1; fi
   - go vet ./...
-  - go test -v -race $PKGS            # Run all the tests with the race detector enabled
+  - GO111MODULE=on go test -v -race $PKGS            # Run all the tests with the race detector enabled
+  - GO111MODULE=off go test -v -race $PKGS           # Make sure tests still pass when not using Go modules.
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! golint ./... | grep -vE "(_mock|_string|\.pb)\.go:"; fi'


### PR DESCRIPTION
Similar rationale to https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/111. 