### PR TITLE
Remove exemplar for now.

### DIFF
--- a/transform_stats_to_metrics.go
+++ b/transform_stats_to_metrics.go
@@ -202,8 +202,8 @@ func rowToPoint(v *view.View, row *view.Row, endTimestamp *timestamp.Timestamp, 
 	case *view.DistributionData:
 		pt.Value = &metricspb.Point_DistributionValue{
 			DistributionValue: &metricspb.DistributionValue{
-				Count:   data.Count,
-				Sum:     float64(data.Count) * data.Mean, // because Mean := Sum/Count
+				Count: data.Count,
+				Sum:   float64(data.Count) * data.Mean, // because Mean := Sum/Count
 				// TODO: Add Exemplar
 				Buckets: bucketsToProtoBuckets(data.CountPerBucket),
 				BucketOptions: &metricspb.DistributionValue_BucketOptions{
@@ -242,7 +242,7 @@ func bucketsToProtoBuckets(countPerBucket []int64) []*metricspb.DistributionValu
 		count := countPerBucket[i]
 
 		distBuckets[i] = &metricspb.DistributionValue_Bucket{
-			Count:    count,
+			Count: count,
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/issues/52
Fixes https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/issues/50

The refactoring with exemplar in core library has caused troubles in build, especially when go module is disabled. Remove all reference of exemplar for now.