### PR TITLE
Expose grpc.DialOption

### DIFF
--- a/ocagent.go
+++ b/ocagent.go
@@ -86,6 +86,8 @@ type Exporter struct {
 	viewDataBundler *bundler.Bundler
 
 	clientTransportCredentials credentials.TransportCredentials
+
+	grpcDialOptions []grpc.DialOption
 }
 
 func NewExporter(opts ...ExporterOption) (*Exporter, error) {
@@ -270,6 +272,9 @@ func (ae *Exporter) dialToAgent() (*grpc.ClientConn, error) {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(ae.compressor)))
 	}
 	dialOpts = append(dialOpts, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}))
+	if len(ae.grpcDialOptions) != 0 {
+		dialOpts = append(dialOpts, ae.grpcDialOptions...)
+	}
 
 	ctx := context.Background()
 	if len(ae.headers) > 0 {

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ package ocagent
 import (
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -125,4 +126,19 @@ func WithTLSCredentials(creds credentials.TransportCredentials) ExporterOption {
 
 func (cc *clientCredentials) withExporter(e *Exporter) {
 	e.clientTransportCredentials = cc.TransportCredentials
+}
+
+type grpcDialOptions []grpc.DialOption
+
+var _ ExporterOption = (*grpcDialOptions)(nil)
+
+// WithGRPCDialOption opens support to any grpc.DialOption to be used. If it conflicts
+// with some other configuration the GRPC specified via the agent the ones here will
+// take preference since they are set last.
+func WithGRPCDialOption(opts ...grpc.DialOption) ExporterOption {
+	return grpcDialOptions(opts)
+}
+
+func (opts grpcDialOptions) withExporter(e *Exporter) {
+	e.grpcDialOptions = opts
 }


### PR DESCRIPTION
There are large number of grpc.DialOptions most of the time users don't need to specify them but when they are needed there is no way to do that. This change exposes all of them, whenever they conflict with settings already exposed by the agent the grpc.DialOption takes precedence by being set last.