### PR TITLE
indefiniteBackgroundConnection shouldn't hold Stop()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -84,7 +84,11 @@ func (ae *Exporter) indefiniteBackgroundConnection() error {
 		// agent-exporters. Lockstep retrials could result in an
 		// innocent DDOS, by clogging the machine's resources and network.
 		jitter := time.Duration(rng.Int63n(maxJitter))
-		<-time.After(connReattemptPeriod + jitter)
+		select {
+		case <-ae.stopCh:
+			return errStopped
+		case <-time.After(connReattemptPeriod + jitter):
+		}
 	}
 }
 


### PR DESCRIPTION
After an attempt to connect there is a wait before going back to the select that waits for disconnected state or closure of the stop channel, however, the wait doesn't check for the stop channel so the Stop can be delayed by connReattemptPeriod (plus any jitter).