### PR TITLE
Record last connection error and attempt connection on Start()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -21,7 +21,7 @@ import (
 	"unsafe"
 )
 
-func (ae *Exporter) loadLastConnectError() error {
+func (ae *Exporter) lastConnectError() error {
 	errPtr := (*error)(atomic.LoadPointer(&ae.lastConnectErrPtr))
 	if errPtr == nil {
 		return nil
@@ -50,7 +50,7 @@ func (ae *Exporter) setStateConnected() {
 }
 
 func (ae *Exporter) connected() bool {
-	return ae.loadLastConnectError() == nil
+	return ae.lastConnectError() == nil
 }
 
 const defaultConnReattemptPeriod = 10 * time.Second

--- a/connection.go
+++ b/connection.go
@@ -29,7 +29,7 @@ func (ae *Exporter) lastConnectError() error {
 	return *errPtr
 }
 
-func (ae *Exporter) storeLastConnectError(err error) {
+func (ae *Exporter) saveLastConnectError(err error) {
 	var errPtr *error
 	if err != nil {
 		errPtr = &err
@@ -38,7 +38,7 @@ func (ae *Exporter) storeLastConnectError(err error) {
 }
 
 func (ae *Exporter) setStateDisconnected(err error) {
-	ae.storeLastConnectError(err)
+	ae.saveLastConnectError(err)
 	select {
 	case ae.disconnectedCh <- true:
 	default:
@@ -46,7 +46,7 @@ func (ae *Exporter) setStateDisconnected(err error) {
 }
 
 func (ae *Exporter) setStateConnected() {
-	ae.storeLastConnectError(nil)
+	ae.saveLastConnectError(nil)
 }
 
 func (ae *Exporter) connected() bool {

--- a/ocagent.go
+++ b/ocagent.go
@@ -139,7 +139,6 @@ var (
 	errAlreadyStarted = errors.New("already started")
 	errNotStarted     = errors.New("not started")
 	errStopped        = errors.New("stopped")
-	errNoConnection   = errors.New("no active connection")
 )
 
 // Start dials to the agent, establishing a connection to it. It also
@@ -380,7 +379,7 @@ func (ae *Exporter) ExportTraceServiceRequest(batch *agenttracepb.ExportTraceSer
 
 	default:
 		if lastConnectErrPtr := ae.loadLastConnectError(); lastConnectErrPtr != nil {
-			return fmt.Errorf("no active connection, last connection error: %v", *lastConnectErrPtr)
+			return fmt.Errorf("ExportTraceServiceRequest: no active connection, last connection error: %v", *lastConnectErrPtr)
 		}
 
 		ae.senderMu.Lock()

--- a/ocagent.go
+++ b/ocagent.go
@@ -388,8 +388,11 @@ func (ae *Exporter) ExportTraceServiceRequest(batch *agenttracepb.ExportTraceSer
 		if err != nil {
 			if err == io.EOF {
 				ae.recvMu.Lock()
-				for _, err = ae.traceExporter.Recv(); err == nil; _, err = ae.traceExporter.Recv() {
-					// Loop until actual error (or io.EOF) is received.
+				for {
+					_, err = ae.traceExporter.Recv()
+					if err != nil {
+						break
+					}
 				}
 				ae.recvMu.Unlock()
 			}

--- a/ocagent.go
+++ b/ocagent.go
@@ -53,8 +53,6 @@ var _ trace.Exporter = (*Exporter)(nil)
 var _ view.Exporter = (*Exporter)(nil)
 
 type Exporter struct {
-	connectionState int32
-
 	// mu protects the non-atomic and non-channel variables
 	mu sync.RWMutex
 	// senderMu protects the concurrent unsafe send on traceExporter client


### PR DESCRIPTION
The changes here benefit most ExportTraceServiceRequest but can also be leveraged in other functions. Changes:

1. Record last error to so ExportTraceServiceRequest can return more information than simply “no active connection”, keeping track of the last connection error made the state kept in a field redundant and as such it was removed.
2. Attempt synchronous connect on Start: this came about in environments with high load where it may takes a long time until the go routine establishing the connection has a chance to run, in such scenario this best effort to connect at start minimizes chances of queueing and dropping at start.
3. In ExportTraceServiceRequest read errors after io.EOF for better reporting on the actual root cause. Notice that io.EOF itself is not considered an error per grpc.

