### PR TITLE
Add a method Exporter.ExportMetricsServiceRequest that accepts proto metrics

### DIFF
--- a/viewdata_to_metrics_test.go
+++ b/viewdata_to_metrics_test.go
@@ -135,6 +135,7 @@ func TestExportMetrics_conversionFromViewData(t *testing.T) {
 					},
 				},
 			},
+			Resource: resourceProtoFromEnv(),
 		},
 	}
 


### PR DESCRIPTION
This will be used when Agent sends proto metrics to Collector.
Also add proto resource to export requests.

Related to https://github.com/open-telemetry/opentelemetry-service/issues/231.

/cc @pjanotti