### PR TITLE
Don't include ParentSpanId when zero

### DIFF
--- a/transform_spans.go
+++ b/transform_spans.go
@@ -38,10 +38,14 @@ func ocSpanToProtoSpan(sd *trace.SpanData) *tracepb.Span {
 	if sd.Name != "" {
 		namePtr = &tracepb.TruncatableString{Value: sd.Name}
 	}
+	var parentSpanID []byte
+	if sd.ParentSpanID != (trace.SpanID{}) {
+		parentSpanID = sd.ParentSpanID[:]
+	}
 	return &tracepb.Span{
 		TraceId:      sd.TraceID[:],
 		SpanId:       sd.SpanID[:],
-		ParentSpanId: sd.ParentSpanID[:],
+		ParentSpanId: parentSpanID,
 		Status:       ocStatusToProtoStatus(sd.Status),
 		StartTime:    timeToTimestamp(sd.StartTime),
 		EndTime:      timeToTimestamp(sd.EndTime),


### PR DESCRIPTION
The [ParentSpanId field](https://github.com/census-instrumentation/opencensus-proto/blob/5cec5ea58c3efa81fa808f2bd38ce182da9ee731/gen-go/trace/v1/trace.pb.go#L158-L160) of [tracepb.Span](https://github.com/census-instrumentation/opencensus-proto/blob/5cec5ea58c3efa81fa808f2bd38ce182da9ee731/gen-go/trace/v1/trace.pb.go#L137) must be empty for the root span.

This causes issues when combined with [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) and the jaeger gRPC exporter.