### PR TITLE
Ensure exporter respects ResourceDetector option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.22.0
 )
+
+go 1.13

--- a/mock_agent_test.go
+++ b/mock_agent_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 )
 
@@ -41,6 +42,8 @@ type mockAgent struct {
 
 	traceNodes      []*commonpb.Node
 	receivedConfigs []*agenttracepb.CurrentLibraryConfig
+
+	resource *resourcepb.Resource
 
 	configsToSend          chan *agenttracepb.UpdatedLibraryConfig
 	closeConfigsToSendOnce sync.Once
@@ -125,6 +128,7 @@ func (ma *mockAgent) Export(tses agenttracepb.TraceService_ExportServer) error {
 			return err
 		}
 		ma.mu.Lock()
+		ma.resource = req.Resource
 		ma.spans = append(ma.spans, req.Spans...)
 		ma.traceNodes = append(ma.traceNodes, req.Node)
 		ma.mu.Unlock()
@@ -213,4 +217,11 @@ func (ma *mockAgent) getTraceNodes() []*commonpb.Node {
 	ma.mu.Unlock()
 
 	return traceNodes
+}
+
+func (ma *mockAgent) getResource() *resourcepb.Resource {
+	ma.mu.Lock()
+	resource := ma.resource
+	ma.mu.Unlock()
+	return resource
 }

--- a/ocagent.go
+++ b/ocagent.go
@@ -1,4 +1,4 @@
-// Copyright 2018, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -504,7 +504,7 @@ func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
 		ae.senderMu.Lock()
 		err := ae.traceExporter.Send(&agenttracepb.ExportTraceServiceRequest{
 			Spans:    protoSpans,
-			Resource: resourceProtoFromEnv(),
+			Resource: ae.resource,
 		})
 		ae.senderMu.Unlock()
 		if err != nil {
@@ -537,7 +537,7 @@ func (ae *Exporter) uploadViewData(vdl []*view.Data) {
 	}
 	req := &agentmetricspb.ExportMetricsServiceRequest{
 		Metrics:  protoMetrics,
-		Resource: resourceProtoFromEnv(),
+		Resource: ae.resource,
 		// TODO:(@odeke-em)
 		// a) Figure out how to derive a Node from the environment
 		// or better letting users of the exporter configure it.

--- a/resource_detector_test.go
+++ b/resource_detector_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenCensus Authors
+// Copyright 2020, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,13 @@ import (
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 )
 
+var (
+	customResource = &resource.Resource{
+		Type:   "foo",
+		Labels: map[string]string{},
+	}
+)
+
 func TestResourceDetector(t *testing.T) {
 	ocexp, err := NewExporter(
 		WithInsecure(),
@@ -46,9 +53,5 @@ func TestResourceDetector(t *testing.T) {
 }
 
 func customResourceDetector(context.Context) (*resource.Resource, error) {
-	res := &resource.Resource{
-		Type:   "foo",
-		Labels: map[string]string{},
-	}
-	return res, nil
+	return customResource, nil
 }


### PR DESCRIPTION
When WithResourceDetector option is used, make sure exporter uses ResourceDetector's detected resource when exporting traces and metrics.

Fixes #79