### PR TITLE
Add an option to set metric name prefix

### DIFF
--- a/options.go
+++ b/options.go
@@ -160,15 +160,15 @@ func (opts grpcDialOptions) withExporter(e *Exporter) {
 	e.grpcDialOptions = opts
 }
 
-type prefixSetter string
+type metricNamePrefixSetter string
 
-var _ ExporterOption = (*prefixSetter)(nil)
+var _ ExporterOption = (*metricNamePrefixSetter)(nil)
 
-func (p prefixSetter) withExporter(e *Exporter) {
+func (p metricNamePrefixSetter) withExporter(e *Exporter) {
 	e.metricNamePerfix = string(p)
 }
 
 // UseMetricNamePrefix provides an option for the caller to add a prefix to metric names.
 func UseMetricNamePrefix(prefix string) ExporterOption {
-	return prefixSetter(prefix)
+	return metricNamePrefixSetter(prefix)
 }

--- a/options.go
+++ b/options.go
@@ -159,3 +159,16 @@ func WithGRPCDialOption(opts ...grpc.DialOption) ExporterOption {
 func (opts grpcDialOptions) withExporter(e *Exporter) {
 	e.grpcDialOptions = opts
 }
+
+type prefixSetter string
+
+var _ ExporterOption = (*prefixSetter)(nil)
+
+func (p prefixSetter) withExporter(e *Exporter) {
+	e.metricNamePerfix = string(p)
+}
+
+// UseMetricNamePrefix provides an option for the caller to add a prefix to metric names.
+func UseMetricNamePrefix(prefix string) ExporterOption {
+	return prefixSetter(prefix)
+}

--- a/options.go
+++ b/options.go
@@ -168,7 +168,7 @@ func (p metricNamePrefixSetter) withExporter(e *Exporter) {
 	e.metricNamePerfix = string(p)
 }
 
-// UseMetricNamePrefix provides an option for the caller to add a prefix to metric names.
-func UseMetricNamePrefix(prefix string) ExporterOption {
+// WithMetricNamePrefix provides an option for the caller to add a prefix to metric names.
+func WithMetricNamePrefix(prefix string) ExporterOption {
 	return metricNamePrefixSetter(prefix)
 }

--- a/transform_stats_to_metrics.go
+++ b/transform_stats_to_metrics.go
@@ -33,12 +33,12 @@ var (
 	errNilViewData = errors.New("expecting a non-nil view.Data")
 )
 
-func viewDataToMetric(vd *view.Data) (*metricspb.Metric, error) {
+func viewDataToMetric(vd *view.Data, metricNamePrefix string) (*metricspb.Metric, error) {
 	if vd == nil {
 		return nil, errNilViewData
 	}
 
-	descriptor, err := viewToMetricDescriptor(vd.View)
+	descriptor, err := viewToMetricDescriptor(vd.View, metricNamePrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func viewDataToMetric(vd *view.Data) (*metricspb.Metric, error) {
 	return metric, nil
 }
 
-func viewToMetricDescriptor(v *view.View) (*metricspb.MetricDescriptor, error) {
+func viewToMetricDescriptor(v *view.View, metricNamePrefix string) (*metricspb.MetricDescriptor, error) {
 	if v == nil {
 		return nil, errNilView
 	}
@@ -63,8 +63,12 @@ func viewToMetricDescriptor(v *view.View) (*metricspb.MetricDescriptor, error) {
 		return nil, errNilMeasure
 	}
 
+	name := stringOrCall(v.Name, v.Measure.Name)
+	if len(metricNamePrefix) > 0 {
+		name = metricNamePrefix + "/" + name
+	}
 	desc := &metricspb.MetricDescriptor{
-		Name:        stringOrCall(v.Name, v.Measure.Name),
+		Name:        name,
 		Description: stringOrCall(v.Description, v.Measure.Description),
 		Unit:        v.Measure.Unit(),
 		Type:        aggregationToMetricDescriptorType(v),


### PR DESCRIPTION
In knative we need to set the component names(autoscaler and activator) as the prefix for metric names.  Both prometheus and stackdriver provide a way to do that:

https://github.com/census-ecosystem/opencensus-go-exporter-prometheus/blob/master/prometheus.go#L170
https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/master/metrics_proto.go#L413

This PR brings the parity to opencensus agent.  

It's hard to test without a mock agent for metrics.  But I tested manually and it worked as expected.