### PR TITLE
Make max annotations and events per span configurable

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -32,7 +32,11 @@ func main() {
 		ocagent.WithInsecure(),
 		ocagent.WithReconnectionPeriod(5*time.Second),
 		ocagent.WithAddress("localhost:55678"), // Only included here for demo purposes.
-		ocagent.WithServiceName("ocagent-go-example"))
+		ocagent.WithServiceName("ocagent-go-example"),
+		ocagent.WithSpanConfig(ocagent.SpanConfig{
+			AnnotationEventsPerSpan: 256,
+			MessageEventsPerSpan:    256,
+		}))
 	if err != nil {
 		log.Fatalf("Failed to create ocagent-exporter: %v", err)
 	}

--- a/ocagent.go
+++ b/ocagent.go
@@ -94,7 +94,7 @@ type Exporter struct {
 
 	grpcDialOptions []grpc.DialOption
 
-	spanConfig 	    SpanConfig
+	spanConfig SpanConfig
 }
 
 func NewExporter(opts ...ExporterOption) (*Exporter, error) {

--- a/ocagent.go
+++ b/ocagent.go
@@ -93,6 +93,8 @@ type Exporter struct {
 	clientTransportCredentials credentials.TransportCredentials
 
 	grpcDialOptions []grpc.DialOption
+
+	spanConfig 	    SpanConfig
 }
 
 func NewExporter(opts ...ExporterOption) (*Exporter, error) {
@@ -475,14 +477,14 @@ func (ae *Exporter) ExportMetricsServiceRequest(batch *agentmetricspb.ExportMetr
 	}
 }
 
-func ocSpanDataToPbSpans(sdl []*trace.SpanData) []*tracepb.Span {
+func ocSpanDataToPbSpans(sdl []*trace.SpanData, spanConfig SpanConfig) []*tracepb.Span {
 	if len(sdl) == 0 {
 		return nil
 	}
 	protoSpans := make([]*tracepb.Span, 0, len(sdl))
 	for _, sd := range sdl {
 		if sd != nil {
-			protoSpans = append(protoSpans, ocSpanToProtoSpan(sd))
+			protoSpans = append(protoSpans, ocSpanToProtoSpan(sd, spanConfig))
 		}
 	}
 	return protoSpans
@@ -498,7 +500,7 @@ func (ae *Exporter) uploadTraces(sdl []*trace.SpanData) {
 			return
 		}
 
-		protoSpans := ocSpanDataToPbSpans(sdl)
+		protoSpans := ocSpanDataToPbSpans(sdl, ae.spanConfig)
 		if len(protoSpans) == 0 {
 			return
 		}

--- a/options.go
+++ b/options.go
@@ -172,3 +172,15 @@ func (p metricNamePrefixSetter) withExporter(e *Exporter) {
 func WithMetricNamePrefix(prefix string) ExporterOption {
 	return metricNamePrefixSetter(prefix)
 }
+
+
+func (spanConfig SpanConfig) withExporter(e *Exporter) {
+	e.spanConfig = spanConfig
+}
+
+var _ ExporterOption = (*SpanConfig)(nil)
+
+// WithSpanConfig allows one to set the AnnotationEventsPerSpan and MessageEventsPerSpan
+func WithSpanConfig(spanConfig SpanConfig) ExporterOption {
+	return spanConfig
+}

--- a/options.go
+++ b/options.go
@@ -173,7 +173,6 @@ func WithMetricNamePrefix(prefix string) ExporterOption {
 	return metricNamePrefixSetter(prefix)
 }
 
-
 func (spanConfig SpanConfig) withExporter(e *Exporter) {
 	e.spanConfig = spanConfig
 }

--- a/span_config.go
+++ b/span_config.go
@@ -23,5 +23,3 @@ func (spanConfig SpanConfig) GetMessageEventsPerSpan() int {
 	}
 	return spanConfig.MessageEventsPerSpan
 }
-
-

--- a/span_config.go
+++ b/span_config.go
@@ -1,0 +1,27 @@
+package ocagent
+
+const (
+	maxAnnotationEventsPerSpan = 32
+	maxMessageEventsPerSpan    = 128
+)
+
+type SpanConfig struct {
+	AnnotationEventsPerSpan int
+	MessageEventsPerSpan    int
+}
+
+func (spanConfig SpanConfig) GetAnnotationEventsPerSpan() int {
+	if spanConfig.AnnotationEventsPerSpan <= 0 {
+		return maxAnnotationEventsPerSpan
+	}
+	return spanConfig.AnnotationEventsPerSpan
+}
+
+func (spanConfig SpanConfig) GetMessageEventsPerSpan() int {
+	if spanConfig.MessageEventsPerSpan <= 0 {
+		return maxMessageEventsPerSpan
+	}
+	return spanConfig.MessageEventsPerSpan
+}
+
+

--- a/span_config_test.go
+++ b/span_config_test.go
@@ -3,20 +3,19 @@ package ocagent
 import "testing"
 
 func TestSpanConfig_GetAnnotationEventsPerSpan(t *testing.T) {
-	tests := [] struct{
-		name string
-		inputSpanConfig SpanConfig
+	tests := []struct {
+		name                   string
+		inputSpanConfig        SpanConfig
 		expectedMaxAnnotations int
 	}{
 		{
-			name: "WhenConfigNotProvided",
-			inputSpanConfig: SpanConfig{},
+			name:                   "WhenConfigNotProvided",
+			inputSpanConfig:        SpanConfig{},
 			expectedMaxAnnotations: 32,
-
 		},
 		{
-			name: "WhenConfigProvided",
-			inputSpanConfig: SpanConfig{AnnotationEventsPerSpan: 256},
+			name:                   "WhenConfigProvided",
+			inputSpanConfig:        SpanConfig{AnnotationEventsPerSpan: 256},
 			expectedMaxAnnotations: 256,
 		},
 	}
@@ -32,20 +31,19 @@ func TestSpanConfig_GetAnnotationEventsPerSpan(t *testing.T) {
 }
 
 func TestSpanConfig_GetMessageEventsPerSpan(t *testing.T) {
-	tests := [] struct{
-		name string
-		inputSpanConfig SpanConfig
+	tests := []struct {
+		name                     string
+		inputSpanConfig          SpanConfig
 		expectedMaxMessageEvents int
 	}{
 		{
-			name: "WhenConfigNotProvided",
-			inputSpanConfig: SpanConfig{},
+			name:                     "WhenConfigNotProvided",
+			inputSpanConfig:          SpanConfig{},
 			expectedMaxMessageEvents: 128,
-
 		},
 		{
-			name: "WhenConfigProvided",
-			inputSpanConfig: SpanConfig{MessageEventsPerSpan: 256},
+			name:                     "WhenConfigProvided",
+			inputSpanConfig:          SpanConfig{MessageEventsPerSpan: 256},
 			expectedMaxMessageEvents: 256,
 		},
 	}

--- a/span_config_test.go
+++ b/span_config_test.go
@@ -1,0 +1,61 @@
+package ocagent
+
+import "testing"
+
+func TestSpanConfig_GetAnnotationEventsPerSpan(t *testing.T) {
+	tests := [] struct{
+		name string
+		inputSpanConfig SpanConfig
+		expectedMaxAnnotations int
+	}{
+		{
+			name: "WhenConfigNotProvided",
+			inputSpanConfig: SpanConfig{},
+			expectedMaxAnnotations: 32,
+
+		},
+		{
+			name: "WhenConfigProvided",
+			inputSpanConfig: SpanConfig{AnnotationEventsPerSpan: 256},
+			expectedMaxAnnotations: 256,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.inputSpanConfig.GetAnnotationEventsPerSpan()
+			if got != test.expectedMaxAnnotations {
+				t.Errorf("Got = %d; want %d", got, test.expectedMaxAnnotations)
+			}
+		})
+	}
+}
+
+func TestSpanConfig_GetMessageEventsPerSpan(t *testing.T) {
+	tests := [] struct{
+		name string
+		inputSpanConfig SpanConfig
+		expectedMaxMessageEvents int
+	}{
+		{
+			name: "WhenConfigNotProvided",
+			inputSpanConfig: SpanConfig{},
+			expectedMaxMessageEvents: 128,
+
+		},
+		{
+			name: "WhenConfigProvided",
+			inputSpanConfig: SpanConfig{MessageEventsPerSpan: 256},
+			expectedMaxMessageEvents: 256,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.inputSpanConfig.GetMessageEventsPerSpan()
+			if got != test.expectedMaxMessageEvents {
+				t.Errorf("Got = %d; want %d", got, test.expectedMaxMessageEvents)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ocagent currently has default max annotations and events values which are not configurable. The annotations in the spans are dropped beyond this value.

opencensus-go provides option to configure span properties like MaxAnnotationEventsPerSpan, MaxMessageEventsPerSpan etc. When integrating opencensus-go with ocagent, opencensus-go provides ability to configure custom values but ocagent has default max values which results in annotations being dropped.

As part of this PR, the properties maxAnnotationEventsPerSpan and maxMessageEventsPerSpan are made configurable and falls back to default values when not specified.