### PR TITLE
Travis build fix and optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
 
 go_import_path: contrib.go.opencensus.io/exporter/ocagent
 
+install: skip
+
 before_script:
   - GO_FILES=$(find . -iname '*.go' | grep -v /vendor/)  # All the .go files, excluding vendor/ if any
   - PKGS=$(go list ./... | grep -v /vendor/)             # All the import paths, excluding vendor/ if any

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ go_import_path: contrib.go.opencensus.io/exporter/ocagent
 before_script:
   - GO_FILES=$(find . -iname '*.go' | grep -v /vendor/)  # All the .go files, excluding vendor/ if any
   - PKGS=$(go list ./... | grep -v /vendor/)             # All the import paths, excluding vendor/ if any
+  - GO111MODULE=on                                       # Depend on go.mod for dependencies
 
 script:
   - go build ./...                    # Ensure dependency updates don't break build
   - if [ -n "$(gofmt -s -l $GO_FILES)" ]; then echo "gofmt the following files:"; gofmt -s -l $GO_FILES; exit 1; fi
   - go vet ./...
-  - GO111MODULE=on go test -v -race $PKGS            # Run all the tests with the race detector enabled
-  - GO111MODULE=off go test -v -race $PKGS           # Make sure tests still pass when not using Go modules.
+  - go test -v -race $PKGS            # Run all the tests with the race detector enabled
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! golint ./... | grep -vE "(_mock|_string|\.pb)\.go:"; fi'


### PR DESCRIPTION
This fixes #86 
Also skipped the install step which triggers travis_install_go_dependencies. This has reduced the build time almost by half as well.