### PR TITLE
Add option to control metrics bundling

### DIFF
--- a/options.go
+++ b/options.go
@@ -173,6 +173,27 @@ func WithMetricNamePrefix(prefix string) ExporterOption {
 	return metricNamePrefixSetter(prefix)
 }
 
+type dataBundlerOptions struct {
+	delay time.Duration
+	count int
+}
+
+var _ ExporterOption = (*dataBundlerOptions)(nil)
+
+func (b dataBundlerOptions) withExporter(e *Exporter) {
+	if b.delay > 0 {
+		e.viewDataDelay = b.delay
+	}
+	if b.count > 0 {
+		e.viewDataBundleCount = b.count
+	}
+}
+
+// WithDataBundlerOptions provides an option for the caller to configure the metrics data bundler.
+func WithDataBundlerOptions(delay time.Duration, count int) ExporterOption {
+	return dataBundlerOptions{delay, count}
+}
+
 func (spanConfig SpanConfig) withExporter(e *Exporter) {
 	e.spanConfig = spanConfig
 }


### PR DESCRIPTION
I discovered that our tests were taking about 2s per OpenCensus exporter created due to the defaults in `NewUnstartedExporter`. This PR allows reducing the defaults (for example, in test situations).